### PR TITLE
Add sensor preprocessing utilities and dataset support for survival analysis

### DIFF
--- a/data.py
+++ b/data.py
@@ -1,11 +1,18 @@
+import os
 import pandas as pd
 import numpy as np
 import torch
 from torch.utils.data import Dataset, DataLoader
 from typing import List, Tuple, Optional
 
-__all__ = ["make_intervals", "build_supervision", "infer_feature_cols",
-           "MultiTaskDataset", "create_dataloaders"]
+__all__ = [
+    "make_intervals",
+    "build_supervision",
+    "infer_feature_cols",
+    "MultiTaskDataset",
+    "SensorDataset",
+    "create_dataloaders",
+]
 
 def make_intervals(
     df: pd.DataFrame,
@@ -113,6 +120,40 @@ class MultiTaskDataset(Dataset):
 
     def __getitem__(self, idx):
         return self.X[idx], self.y[idx], self.m[idx]
+
+
+class SensorDataset(Dataset):
+    """Dataset for preprocessed sensor sequences per patient.
+
+    Each patient has a ``.npy`` file named ``<patient_id>.npy`` inside a
+    directory. The file should contain a numeric array of shape ``(T, F)``.
+
+    Parameters
+    ----------
+    directory : str
+        Path to the directory containing ``.npy`` files.
+    patient_ids : list of str, optional
+        Subset of patient identifiers to load. If ``None``, all ``.npy`` files
+        in ``directory`` are used.
+    """
+
+    def __init__(self, directory: str, patient_ids: Optional[List[str]] = None):
+        self.directory = directory
+        if patient_ids is None:
+            files = [f for f in os.listdir(directory) if f.endswith(".npy")]
+            patient_ids = [os.path.splitext(f)[0] for f in files]
+            patient_ids.sort()
+        self.patient_ids = patient_ids
+
+    def __len__(self) -> int:
+        return len(self.patient_ids)
+
+    def __getitem__(self, idx: int):
+        pid = self.patient_ids[idx]
+        path = os.path.join(self.directory, f"{pid}.npy")
+        arr = np.load(path)
+        tensor = torch.from_numpy(arr.astype(np.float32))
+        return pid, tensor
 
 
 def create_dataloaders(

--- a/preprocess/sensor.py
+++ b/preprocess/sensor.py
@@ -1,0 +1,95 @@
+"""Utility functions for processing raw sensor time-series."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+__all__ = ["resample_signal", "normalize_signal", "window_signal"]
+
+
+def resample_signal(df: pd.DataFrame, time_col: str, freq: str, method: str = "mean") -> pd.DataFrame:
+    """Resample a time-indexed DataFrame to a new frequency.
+
+    Parameters
+    ----------
+    df : DataFrame
+        Input data containing a time column.
+    time_col : str
+        Name of the column representing timestamps.
+    freq : str
+        Target pandas frequency string (e.g., ``'1S'`` for 1-second).
+    method : str, optional
+        Aggregation method: ``'mean'`` (default) or ``'nearest'``.
+
+    Returns
+    -------
+    DataFrame
+        Resampled DataFrame with the same columns as ``df``.
+    """
+    if not np.issubdtype(df[time_col].dtype, np.datetime64):
+        df = df.copy()
+        df[time_col] = pd.to_datetime(df[time_col])
+    df = df.set_index(time_col).sort_index()
+    if method == "nearest":
+        resampled = df.resample(freq).nearest()
+    else:
+        resampled = df.resample(freq).mean()
+    return resampled.reset_index()
+
+
+def normalize_signal(arr: np.ndarray, method: str = "zscore") -> np.ndarray:
+    """Normalize a sensor signal.
+
+    Parameters
+    ----------
+    arr : ndarray
+        Input array of shape (T, F) or (T,).
+    method : str, optional
+        ``'zscore'`` (default) for zero-mean/unit-var or ``'minmax'``.
+
+    Returns
+    -------
+    ndarray
+        Normalized array with the same shape as ``arr``.
+    """
+    arr = np.asarray(arr, dtype=float)
+    if method == "minmax":
+        min_ = arr.min(axis=0, keepdims=True)
+        max_ = arr.max(axis=0, keepdims=True)
+        denom = max_ - min_
+        denom[denom == 0] = 1.0
+        return (arr - min_) / denom
+    else:  # z-score
+        mean = arr.mean(axis=0, keepdims=True)
+        std = arr.std(axis=0, keepdims=True)
+        std[std == 0] = 1.0
+        return (arr - mean) / std
+
+
+def window_signal(arr: np.ndarray, window_size: int, step: int | None = None) -> np.ndarray:
+    """Create overlapping windows from a time-series array.
+
+    Parameters
+    ----------
+    arr : ndarray
+        Array of shape (T, F) or (T,).
+    window_size : int
+        Number of time steps per window.
+    step : int, optional
+        Step size between windows. Defaults to ``window_size`` (non-overlapping).
+
+    Returns
+    -------
+    ndarray
+        Array of shape (N, window_size, F) containing windows. ``N`` may be zero
+        if the sequence is shorter than ``window_size``.
+    """
+    arr = np.asarray(arr)
+    if step is None:
+        step = window_size
+    n_steps = arr.shape[0]
+    windows = [arr[start:start + window_size] for start in range(0, n_steps - window_size + 1, step)]
+    if not windows:
+        return np.empty((0, window_size) + arr.shape[1:])
+    return np.stack(windows)

--- a/sa_tools.py
+++ b/sa_tools.py
@@ -76,10 +76,24 @@ def run_survival_analysis(
     batch_size: int = 64,
     epochs: int = 100,
     lr: float = 0.01,
+    sampling_rate: float | None = None,
+    window_size: int | None = None,
     **kwargs
 ) -> dict:
-    """
-    Runs a specified survival analysis model on the currently loaded dataset.
+    """Runs a specified survival analysis model on the currently loaded dataset.
+
+    Parameters
+    ----------
+    algorithm_name : str
+        Name of the algorithm to run.
+    time_col, event_col : str
+        Columns identifying duration and event indicator.
+    batch_size, epochs, lr : int or float
+        Training hyperparameters.
+    sampling_rate : float, optional
+        Desired sampling rate (Hz) for sensor processing.
+    window_size : int, optional
+        Length of sliding windows for sensor sequences.
     """
     # 确保 DataManager 存在
     if "data_manager" not in st.session_state:
@@ -106,6 +120,11 @@ def run_survival_analysis(
         "event_col": "event",
         "feature_cols": feature_cols,
     }
+
+    if sampling_rate is not None:
+        config["sampling_rate"] = float(sampling_rate)
+    if window_size is not None:
+        config["window_size"] = int(window_size)
 
     # 透传 MySA/TEXGISA 的可选参数（如果调用方传了就生效）
     passthrough = [


### PR DESCRIPTION
## Summary
- add sensor preprocessing helpers for resampling, normalization, and windowing
- add `SensorDataset` for loading per-patient processed sensor sequences
- expose sampling rate and window size options in `run_survival_analysis`

## Testing
- `python -m py_compile data.py sa_tools.py preprocess/sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b65f7a5b7c832b85407aafaecd6cfa