### PR TITLE
Add image preprocessing and multimodal dataset support

### DIFF
--- a/data.py
+++ b/data.py
@@ -192,7 +192,7 @@ class MultiModalDataset(Dataset):
     def __len__(self) -> int:
         return len(self.df)
 
-    def __getitem__(self, idx: int):
+    def __getitem__(self, idx: int) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor, torch.Tensor]:
         row = self.df.iloc[idx]
         tabular = torch.tensor(row[self.feature_cols].values, dtype=torch.float32)
         duration = torch.tensor(row[self.time_col], dtype=torch.float32)
@@ -218,7 +218,7 @@ def create_dataloaders(
     train_ds = MultiTaskDataset(X_train, y_train, m_train)
     val_ds   = MultiTaskDataset(X_val,   y_val,   m_val)
 
-# make pin/persistent safe for both CPU and GPU + num_workers=0
+    # make pin/persistent safe for both CPU and GPU + num_workers=0
     pin_memory = torch.cuda.is_available()
     use_persistent = bool(num_workers and num_workers > 0)
 

--- a/data.py
+++ b/data.py
@@ -2,10 +2,19 @@ import pandas as pd
 import numpy as np
 import torch
 from torch.utils.data import Dataset, DataLoader
-from typing import List, Tuple, Optional
+from typing import List, Tuple, Optional, Callable
 
-__all__ = ["make_intervals", "build_supervision", "infer_feature_cols",
-           "MultiTaskDataset", "create_dataloaders"]
+from sa_data_manager import DataManager
+from preprocess.image import load_image, default_image_transform
+
+__all__ = [
+    "make_intervals",
+    "build_supervision",
+    "infer_feature_cols",
+    "MultiTaskDataset",
+    "MultiModalDataset",
+    "create_dataloaders",
+]
 
 def make_intervals(
     df: pd.DataFrame,
@@ -113,6 +122,91 @@ class MultiTaskDataset(Dataset):
 
     def __getitem__(self, idx):
         return self.X[idx], self.y[idx], self.m[idx]
+
+
+class MultiModalDataset(Dataset):
+    """Dataset handling tabular and image data loaded from :class:`DataManager`.
+
+    Parameters
+    ----------
+    data_manager: DataManager
+        Manager holding the DataFrame with data. The DataFrame must contain
+        columns for the tabular features, the survival labels, and optionally
+        a column with image file paths.
+    feature_cols: List[str]
+        Names of numeric columns to be used as tabular features.
+    time_col: str
+        Column name for the event/censoring time.
+    event_col: str
+        Column name for the event indicator (1 if event occurred, else 0).
+    image_path_col: Optional[str]
+        Column containing file paths to the images. If ``None``, image tensors
+        are omitted.
+    transform: callable, optional
+        Transformation applied to images. Defaults to
+        :func:`preprocess.image.default_image_transform`.
+    encoder: Optional[str]
+        Name of a torchvision model to use for feature extraction. Currently
+        supports ``"resnet18"``. If ``None``, raw image tensors are returned.
+    """
+
+    def __init__(
+        self,
+        data_manager: DataManager,
+        feature_cols: List[str],
+        time_col: str,
+        event_col: str,
+        image_path_col: Optional[str] = None,
+        transform: Optional[Callable] = None,
+        encoder: Optional[str] = None,
+    ):
+        df = data_manager.get_data()
+        if df is None:
+            raise ValueError("DataManager has no data loaded.")
+
+        self.df = df.reset_index(drop=True)
+        self.feature_cols = feature_cols
+        self.time_col = time_col
+        self.event_col = event_col
+        self.image_path_col = image_path_col
+        self.transform = transform or default_image_transform()
+        self.encoder = self._init_encoder(encoder)
+
+    def _init_encoder(self, name: Optional[str]):
+        if not name:
+            return None
+
+        name = name.lower()
+        if name == "resnet18":
+            from torchvision.models import resnet18, ResNet18_Weights
+
+            model = resnet18(weights=ResNet18_Weights.DEFAULT)
+            modules = list(model.children())[:-1]
+            encoder = torch.nn.Sequential(*modules)
+            encoder.eval()
+            for p in encoder.parameters():
+                p.requires_grad = False
+            return encoder
+        raise ValueError(f"Unknown encoder: {name}")
+
+    def __len__(self) -> int:
+        return len(self.df)
+
+    def __getitem__(self, idx: int):
+        row = self.df.iloc[idx]
+        tabular = torch.tensor(row[self.feature_cols].values, dtype=torch.float32)
+        duration = torch.tensor(row[self.time_col], dtype=torch.float32)
+        event = torch.tensor(row[self.event_col], dtype=torch.float32)
+
+        image = None
+        if self.image_path_col is not None:
+            path = row[self.image_path_col]
+            image = load_image(path, self.transform)
+            if self.encoder is not None:
+                with torch.no_grad():
+                    image = self.encoder(image.unsqueeze(0)).squeeze()
+
+        return tabular, image, duration, event
 
 
 def create_dataloaders(

--- a/preprocess/__init__.py
+++ b/preprocess/__init__.py
@@ -1,0 +1,5 @@
+"""Preprocessing utilities for the SAWEB project."""
+
+from .image import load_image, default_image_transform
+
+__all__ = ["load_image", "default_image_transform"]

--- a/preprocess/image.py
+++ b/preprocess/image.py
@@ -1,0 +1,38 @@
+"""Image preprocessing utilities."""
+
+from PIL import Image
+from torchvision import transforms
+from typing import Tuple, Optional
+
+# Mean and std for normalization using ImageNet statistics
+IMAGENET_MEAN = [0.485, 0.456, 0.406]
+IMAGENET_STD = [0.229, 0.224, 0.225]
+
+
+def default_image_transform(size: Tuple[int, int] = (224, 224)) -> transforms.Compose:
+    """Return a torchvision transform for resizing and normalizing images."""
+    return transforms.Compose(
+        [
+            transforms.Resize(size),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=IMAGENET_MEAN, std=IMAGENET_STD),
+        ]
+    )
+
+
+def load_image(path: str, transform: Optional[transforms.Compose] = None) -> transforms.Tensor:
+    """Load an image from ``path`` and apply ``transform``.
+
+    Parameters
+    ----------
+    path: str
+        File path to the image.
+    transform: torchvision.transforms.Compose, optional
+        Transformation pipeline to apply. If ``None``, :func:`default_image_transform`
+        is used.
+    """
+    img = Image.open(path).convert("RGB")
+    transform = transform or default_image_transform()
+    return transform(img)
+
+__all__ = ["load_image", "default_image_transform", "IMAGENET_MEAN", "IMAGENET_STD"]

--- a/sa_tools.py
+++ b/sa_tools.py
@@ -3,6 +3,7 @@
 import json
 import streamlit as st
 import pandas as pd
+from typing import Optional
 from models import coxtime, deepsurv, deephit
 
 # Prefer the new MySA; fall back to legacy texgisa; allow missing
@@ -76,6 +77,7 @@ def run_survival_analysis(
     batch_size: int = 64,
     epochs: int = 100,
     lr: float = 0.01,
+    image_encoder: Optional[str] = None,
     **kwargs
 ) -> dict:
     """
@@ -106,13 +108,15 @@ def run_survival_analysis(
         "event_col": "event",
         "feature_cols": feature_cols,
     }
+    if image_encoder is not None:
+        config["image_encoder"] = image_encoder
 
     # 透传 MySA/TEXGISA 的可选参数（如果调用方传了就生效）
     passthrough = [
         "lambda_smooth", "lambda_expert", "expert_rules",
         "ig_steps", "latent_dim", "extreme_dim",
         "gen_epochs", "gen_batch", "gen_lr", "gen_alpha_dist",
-        "num_intervals", "n_bins"
+        "num_intervals", "n_bins", "image_encoder"
     ]
     for k in passthrough:
         if k in kwargs and kwargs[k] is not None:

--- a/sa_tools.py
+++ b/sa_tools.py
@@ -116,7 +116,7 @@ def run_survival_analysis(
         "lambda_smooth", "lambda_expert", "expert_rules",
         "ig_steps", "latent_dim", "extreme_dim",
         "gen_epochs", "gen_batch", "gen_lr", "gen_alpha_dist",
-        "num_intervals", "n_bins", "image_encoder"
+        "num_intervals", "n_bins"
     ]
     for k in passthrough:
         if k in kwargs and kwargs[k] is not None:


### PR DESCRIPTION
## Summary
- add torchvision-based image preprocessing utilities
- introduce `MultiModalDataset` for tabular and image data with optional ResNet encoding
- expose `image_encoder` option in `run_survival_analysis` config

## Testing
- `python -m py_compile preprocess/image.py data.py sa_tools.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b65f7da304832b86067e8cfb5027ac