### PR TITLE
Add sensor and image uploaders with preprocessing options

### DIFF
--- a/pages_logic/run_models.py
+++ b/pages_logic/run_models.py
@@ -1,0 +1,38 @@
+import streamlit as st
+from sa_data_manager import DataManager
+
+# Ensure DataManager exists in session state
+if "data_manager" not in st.session_state:
+    st.session_state.data_manager = DataManager()
+manager = st.session_state.data_manager
+
+st.title("Run Models")
+
+# Sidebar options for preprocessing
+st.sidebar.header("Preprocessing Options")
+resample_rate = st.sidebar.number_input("Resample rate (Hz)", min_value=1, value=100)
+image_resize = st.sidebar.number_input("Image resize (pixels)", min_value=1, value=224)
+
+# Sensor file uploader
+sensor_file = st.file_uploader(
+    "Upload sensor data (CSV or JSON)",
+    type=["csv", "json"],
+)
+if sensor_file is not None:
+    sensor_names = manager.load_sensor(sensor_file)
+    if sensor_names:
+        st.write("Detected sensor file(s):")
+        for name in sensor_names:
+            st.write(name)
+
+# Image file uploader
+image_file = st.file_uploader(
+    "Upload image data (ZIP)",
+    type=["zip"],
+)
+if image_file is not None:
+    image_names = manager.load_image(image_file)
+    if image_names:
+        st.write("Detected image file(s):")
+        for name in image_names:
+            st.write(name)

--- a/sa_data_manager.py
+++ b/sa_data_manager.py
@@ -1,19 +1,48 @@
 # sa_data_manager.py (Updated Version)
 
 import pandas as pd
-from typing import Optional
+import zipfile
+from typing import Optional, List
 
 class DataManager:
     """A simple singleton-like class to manage the active dataset."""
     def __init__(self):
         self._data: Optional[pd.DataFrame] = None
         self._file_name: Optional[str] = None # Add file_name attribute
+        self._image_files: List[str] = []
 
     def load_data(self, data: pd.DataFrame, file_name: str): # Add file_name parameter
         """Loads a pandas DataFrame and its file name into the manager."""
         print(f"Data from '{file_name}' loaded into SA Data Manager.")
         self._data = data
         self._file_name = file_name
+
+    def load_sensor(self, file) -> List[str]:
+        """Loads sensor data from a CSV or JSON file."""
+        if file.name.endswith('.csv'):
+            data = pd.read_csv(file)
+        elif file.name.endswith('.json'):
+            data = pd.read_json(file)
+        else:
+            raise ValueError("Unsupported sensor file format.")
+        self.load_data(data, file.name)
+        return [file.name]
+
+    def load_image(self, file) -> List[str]:
+        """Loads image file names from a ZIP archive."""
+        with zipfile.ZipFile(file) as zf:
+            image_names = [
+                info.filename
+                for info in zf.infolist()
+                if info.filename.lower().endswith(('.png', '.jpg', '.jpeg', '.bmp', '.gif'))
+            ]
+        self._image_files = image_names
+        self._file_name = file.name
+        return image_names
+
+    def get_image_files(self) -> List[str]:
+        """Returns the names of loaded image files."""
+        return self._image_files
 
     def get_data(self) -> Optional[pd.DataFrame]:
         """Retrieves the loaded DataFrame."""


### PR DESCRIPTION
## Summary
- add `DataManager.load_sensor` and `load_image` to handle CSV/JSON sensor data and image ZIPs
- create run-models page with separate uploaders and preprocessing controls

## Testing
- `python -m py_compile sa_data_manager.py pages_logic/run_models.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b660ec1278832b98d10b7a84fbdd7e