### PR TITLE
Render sensor and image summaries after dataset upload

### DIFF
--- a/pages_logic/__init__.py
+++ b/pages_logic/__init__.py
@@ -1,0 +1,1 @@
+# pages_logic package

--- a/pages_logic/run_models.py
+++ b/pages_logic/run_models.py
@@ -1,0 +1,50 @@
+import pandas as pd
+import streamlit as st
+
+from sa_data_manager import DataManager
+
+
+def _read_dataframe(uploaded_file) -> pd.DataFrame:
+    """Read uploaded file into a DataFrame."""
+    if uploaded_file.name.endswith(".csv"):
+        return pd.read_csv(uploaded_file)
+    if uploaded_file.name.endswith(".parquet"):
+        return pd.read_parquet(uploaded_file)
+    raise ValueError("Unsupported file type")
+
+
+def show() -> None:
+    """Render the model-running page with data summaries."""
+    st.header("Model Training")
+
+    uploaded = st.file_uploader("Upload dataset", type=["csv", "parquet"])
+    if uploaded is None:
+        return
+
+    df = _read_dataframe(uploaded)
+
+    data_manager: DataManager = st.session_state.data_manager
+    data_manager.load_data(df, uploaded.name)
+
+    # Consolidated summary
+    st.subheader("Dataset Summary")
+    st.json(data_manager.get_data_summary())
+
+    # Sensor stats
+    st.subheader("Sensor Summary")
+    sensor_summary = data_manager.get_sensor_summary()
+    if isinstance(sensor_summary, dict) and sensor_summary.get("error"):
+        st.info(sensor_summary["error"])
+    else:
+        st.table(pd.DataFrame(sensor_summary))  # type: ignore[arg-type]
+
+    # Image stats
+    st.subheader("Image Summary")
+    image_summary = data_manager.get_image_summary()
+    if isinstance(image_summary, dict) and image_summary.get("error"):
+        st.info(image_summary["error"])
+    else:
+        for item in image_summary:  # type: ignore[assignment]
+            st.write(f"Column: {item['column']}")
+            st.write(f"Shape: {item['shape']}")
+            st.image(item["image"], width=100)

--- a/sa_data_manager.py
+++ b/sa_data_manager.py
@@ -1,7 +1,11 @@
 # sa_data_manager.py (Updated Version)
 
+import io
+from typing import Optional, List, Dict, Any, Union
+
+import numpy as np
 import pandas as pd
-from typing import Optional
+from PIL import Image
 
 class DataManager:
     """A simple singleton-like class to manage the active dataset."""
@@ -23,7 +27,7 @@ class DataManager:
         """Returns a summary of the loaded data."""
         if self._data is None:
             return {"error": "No data has been loaded. Please upload a dataset on the 'Run Models' page."}
-        
+
         return {
             "file_name": self._file_name,
             "num_rows": int(self._data.shape[0]),
@@ -31,4 +35,62 @@ class DataManager:
             "column_names": self._data.columns.tolist(),
             "missing_values": self._data.isnull().sum().to_dict()
         }
+
+    def get_sensor_summary(self) -> Union[List[Dict[str, int]], Dict[str, str]]:
+        """Return length and channel information for sensor-like columns."""
+        if self._data is None:
+            return {"error": "No data has been loaded. Please upload a dataset on the 'Run Models' page."}
+
+        summaries: List[Dict[str, int]] = []
+        for col in self._data.columns:
+            series = self._data[col].dropna()
+            if series.empty:
+                continue
+            first = series.iloc[0]
+            if isinstance(first, (list, tuple, np.ndarray, pd.Series)):
+                arr = np.asarray(first)
+                length = int(arr.shape[0])
+                channels = int(arr.shape[1]) if arr.ndim > 1 else 1
+                summaries.append({"column": col, "length": length, "channels": channels})
+        if not summaries:
+            return {"error": "No sensor data columns detected."}
+        return summaries
+
+    def get_image_summary(self) -> Union[List[Dict[str, Any]], Dict[str, str]]:
+        """Return thumbnails and shapes for image-like columns."""
+        if self._data is None:
+            return {"error": "No data has been loaded. Please upload a dataset on the 'Run Models' page."}
+
+        summaries: List[Dict[str, Any]] = []
+        for col in self._data.columns:
+            series = self._data[col].dropna()
+            if series.empty:
+                continue
+            first = series.iloc[0]
+            image = None
+            if isinstance(first, Image.Image):
+                image = first
+            elif isinstance(first, (bytes, bytearray)):
+                try:
+                    image = Image.open(io.BytesIO(first))
+                except Exception:
+                    image = None
+            elif isinstance(first, np.ndarray):
+                try:
+                    image = Image.fromarray(first)
+                except Exception:
+                    image = None
+            elif isinstance(first, str) and first.lower().endswith((".png", ".jpg", ".jpeg", ".bmp", ".gif", ".tiff")):
+                try:
+                    image = Image.open(first)
+                except Exception:
+                    image = None
+
+            if image is not None:
+                shape = (image.height, image.width, len(image.getbands()))
+                summaries.append({"column": col, "image": image, "shape": shape})
+
+        if not summaries:
+            return {"error": "No image data columns detected."}
+        return summaries
 


### PR DESCRIPTION
## Summary
- extend `DataManager` with `get_sensor_summary` and `get_image_summary` for per-column analysis
- create `pages_logic.run_models` to upload datasets and display consolidated, sensor, and image summaries

## Testing
- `python -m py_compile sa_data_manager.py pages_logic/run_models.py`


------
https://chatgpt.com/codex/tasks/task_e_68b660ed49ec832ba1bdad59a94ec52f