### PR TITLE
feat: add multimodal survival model

### DIFF
--- a/models/multimodal_survival.py
+++ b/models/multimodal_survival.py
@@ -1,0 +1,70 @@
+import torch
+import torch.nn as nn
+from typing import Dict, Optional
+
+
+class MultiModalSurvivalModel(nn.Module):
+    """Simple multimodal survival model with gating-based fusion.
+
+    Each modality has a dedicated encoder producing a representation of the
+    same dimensionality. During ``forward`` the model accepts a dictionary of
+    modality inputs and a ``modality_masks`` tensor indicating which modalities
+    are present for each sample. Missing modalities are zeroed-out and excluded
+    from the fusion weights. The fusion is performed via a lightweight gating
+    mechanism similar to a Gated Multimodal Unit.
+    """
+
+    def __init__(self, encoders: Dict[str, nn.Module], hidden_dim: int, num_bins: int):
+        super().__init__()
+        self.encoders = nn.ModuleDict(encoders)
+        self.modality_names = list(encoders.keys())
+        self.hidden_dim = hidden_dim
+
+        # gating layers produce a single logit per modality
+        self.gates = nn.ModuleDict({name: nn.Linear(hidden_dim, 1) for name in self.modality_names})
+        # final hazard head
+        self.hazard_layer = nn.Linear(hidden_dim, num_bins)
+
+        for m in self.modules():
+            if isinstance(m, nn.Linear):
+                nn.init.xavier_uniform_(m.weight)
+                if m.bias is not None:
+                    nn.init.zeros_(m.bias)
+
+    def forward(self, inputs: Dict[str, torch.Tensor], modality_masks: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """Forward pass with modality masking.
+
+        Parameters
+        ----------
+        inputs: Dict[str, Tensor]
+            Mapping from modality name to its input tensor.
+        modality_masks: Tensor of shape [B, M], optional
+            1 indicates the modality is available for a given sample. Missing
+            modalities are zeroed-out and ignored in fusion.
+        """
+        B = next(iter(inputs.values())).shape[0]
+        M = len(self.modality_names)
+        if modality_masks is None:
+            modality_masks = inputs[next(iter(inputs))].new_ones(B, M)
+
+        feats = []
+        gate_logits = []
+        for i, name in enumerate(self.modality_names):
+            x = inputs.get(name)
+            h = self.encoders[name](x)
+            mask = modality_masks[:, i].unsqueeze(1)
+            h = h * mask  # zero-out missing modality
+            feats.append(h)
+            gate_logits.append(self.gates[name](h))
+
+        gate_logits = torch.cat(gate_logits, dim=1)
+        # mask out missing modalities in gating by adding large negative number
+        gate_logits = gate_logits + (modality_masks - 1) * 1e9
+        attn = torch.softmax(gate_logits, dim=1)  # [B, M]
+
+        fused = torch.zeros(B, self.hidden_dim, device=attn.device)
+        for i in range(M):
+            fused = fused + feats[i] * attn[:, i].unsqueeze(1)
+
+        hazards = torch.sigmoid(self.hazard_layer(fused))
+        return hazards

--- a/multimodal_dataset.py
+++ b/multimodal_dataset.py
@@ -1,0 +1,62 @@
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+from typing import Dict, List, Optional
+
+
+class MultiModalDataset(Dataset):
+    """Dataset that stores multiple modalities and their availability masks.
+
+    Parameters
+    ----------
+    modalities: Dict[str, np.ndarray]
+        Mapping from modality name to array of shape [N, ...]. All modalities
+        must share the same number of samples ``N``.
+    labels: np.ndarray
+        Event labels in one-hot encoding of shape [N, T].
+    masks: np.ndarray
+        Risk-set masks of shape [N, T].
+    modality_available: Optional[np.ndarray]
+        Boolean array [N, M] indicating which modalities are present for each
+        sample. If ``None`` we assume every modality is available.
+    modality_dropout: float, optional
+        Probability of randomly dropping a modality during training to improve
+        robustness.
+    train: bool
+        Whether this dataset will be used for training (enables dropout).
+    """
+
+    def __init__(
+        self,
+        modalities: Dict[str, np.ndarray],
+        labels: np.ndarray,
+        masks: np.ndarray,
+        modality_available: Optional[np.ndarray] = None,
+        modality_dropout: float = 0.0,
+        train: bool = True,
+    ) -> None:
+        self.modalities = {k: torch.from_numpy(v).float() for k, v in modalities.items()}
+        self.labels = torch.from_numpy(labels).float()
+        self.masks = torch.from_numpy(masks).float()
+        self.modality_names: List[str] = list(modalities.keys())
+        self.train = train
+        self.modality_dropout = float(modality_dropout)
+
+        N = self.labels.shape[0]
+        M = len(self.modality_names)
+        if modality_available is None:
+            modality_available = np.ones((N, M), dtype=np.float32)
+        self.modality_available = torch.from_numpy(modality_available).float()
+
+    def __len__(self) -> int:  # type: ignore[override]
+        return self.labels.shape[0]
+
+    def __getitem__(self, idx: int):  # type: ignore[override]
+        x = {k: v[idx] for k, v in self.modalities.items()}
+        mod_mask = self.modality_available[idx].clone()
+
+        if self.train and self.modality_dropout > 0.0:
+            drop = torch.rand_like(mod_mask) < self.modality_dropout
+            mod_mask = mod_mask * (~drop).float()
+
+        return x, self.labels[idx], self.masks[idx], mod_mask


### PR DESCRIPTION
## Summary
- add `MultiModalSurvivalModel` supporting modality masks and gated fusion
- introduce `MultiModalDataset` tracking modality availability with optional dropout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf9dae4ae8832ba9922c654fc96198