### PR TITLE
Fix tensor conversions in cindex_fast

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -9,9 +9,11 @@ def cindex_fast(durations, events, risks):
     events:    [N] 0/1 int/float tensor
     risks:     [N] float tensor (e.g., sum of hazards or cumulative hazard)
     """
-    durations = durations.view(-1)
-    events    = events.view(-1)
-    risks     = risks.view(-1)
+    risks = torch.as_tensor(risks)
+    device = torch.device(risks.device)
+    durations = torch.as_tensor(durations, device=device).view(-1)
+    events    = torch.as_tensor(events, device=device).view(-1)
+    risks     = risks.to(device).view(-1)
 
     # Only comparable pairs where one is an event and the other is at risk longer
     # Create pairwise masks: i < j to avoid double counting


### PR DESCRIPTION
## Summary
- Cast duration, event, and risk inputs to tensors in `cindex_fast`
- Ensure inputs reside on the same device as the risk tensor

## Testing
- `python test.py` *(fails: can't open file '/workspace/SAWEB/test.py')*


------
https://chatgpt.com/codex/tasks/task_e_68c1e5ce0be4832b8468aee0c1f34713