### PR TITLE
Enable raw multimodal ingestion workflow

### DIFF
--- a/image_pipeline.py
+++ b/image_pipeline.py
@@ -137,6 +137,7 @@ def images_to_dataframe(
     image_col: str = "image",
     duration_col: str = "duration",
     event_col: str = "event",
+    id_col: Optional[str] = "id",
     batch_size: int = 64,
     num_workers: int = 2,
     device: Optional[str] = None,
@@ -185,7 +186,11 @@ def images_to_dataframe(
     feat_df = pd.DataFrame(feats, columns=feat_cols)
     df = pd.concat([df, feat_df], axis=1)
 
-    # 3) 保留 manifest 中的额外数值特征
+    # 3) 若提供了 ID 列，则保留在最前面方便与其他模态对齐
+    if id_col and id_col in kept.columns:
+        df.insert(0, id_col, kept[id_col].to_numpy())
+
+    # 4) 保留 manifest 中的额外数值特征
     extra_cols = [c for c in kept.columns if c not in {image_col, duration_col, event_col, "_orig_idx"}]
     for c in extra_cols:
         # 仅保留可数值化的列（非数值会被跳过或变成 NaN→填 0）

--- a/pages_logic/run_models.py
+++ b/pages_logic/run_models.py
@@ -9,6 +9,7 @@ import streamlit as st
 import matplotlib.pyplot as plt
 import pandas as pd
 import numpy as np
+from typing import Any, Dict, Optional
 
 from models import coxtime, deepsurv, deephit
 from models.mysa import run_mysa as run_texgisa
@@ -475,6 +476,57 @@ def _build_expert_rules_from_editor(df_rules):
     return {"rules": rules}
 
 
+def _build_multimodal_sources(config: dict) -> Optional[Dict[str, Any]]:
+    dm = st.session_state.get("data_manager") if "data_manager" in st.session_state else None
+    if dm is None:
+        return None
+
+    has_image = getattr(dm, "image_df", None) is not None
+    has_sensor = getattr(dm, "sensor_df", None) is not None
+    if not (has_image or has_sensor):
+        return None
+
+    id_col = st.session_state.get("mm_tab_id")
+    if not id_col:
+        return None
+
+    sources: Dict[str, Any] = {"id_col": id_col}
+
+    tab_df = getattr(dm, "tabular_df", None)
+    if tab_df is not None:
+        sources["tabular"] = {
+            "data": tab_df.copy(),
+            "id_col": id_col,
+            "feature_cols": config.get("feature_cols"),
+        }
+
+    if has_image:
+        img_df = dm.image_df
+        img_id = st.session_state.get("mm_img_id") or id_col
+        img_feats = [c for c in img_df.columns if c not in {img_id, "duration", "event"}]
+        sources["image"] = {
+            "data": img_df.copy(),
+            "id_col": img_id,
+            "feature_cols": img_feats,
+        }
+
+    if has_sensor:
+        sens_df = dm.sensor_df
+        sens_id = st.session_state.get("mm_sens_id") or id_col
+        sens_feats = [c for c in sens_df.columns if c not in {sens_id, "duration", "event"}]
+        sources["sensor"] = {
+            "data": sens_df.copy(),
+            "id_col": sens_id,
+            "feature_cols": sens_feats,
+        }
+
+    extra_modalities = [k for k in ("image", "sensor") if k in sources and sources[k]["feature_cols"]]
+    if not extra_modalities:
+        return None
+
+    return sources
+
+
 def _plot_survival_curves(surv_df: pd.DataFrame, max_lines: int = 5):
     st.subheader("Predicted Survival Trajectories")
     fig, ax = plt.subplots(figsize=(10, 6))
@@ -618,6 +670,7 @@ def show():
         images_to_dataframe,
         build_manifest_from_zip,
         manifest_template_csv_bytes,
+        unzip_images_to_temp,
     )
 
     # === New: Image ZIP wizard (ResNet-50 -> Features) =============================
@@ -774,6 +827,7 @@ def show():
         build_manifest_from_sensors_zip,
         manifest_template_csv_bytes as manifest_template_csv_bytes_sensor,
         sensors_to_dataframe,
+        unzip_sensors_to_temp,
     )
 
     with st.expander("📈 Build Training Data from Sensor Data (Full-sequence Features)", expanded=False):
@@ -900,81 +954,243 @@ def show():
 
     # ===================== Multimodal data upload =============================
     with st.expander("🗂 Multimodal Data Upload", expanded=False):
-        tab_up = st.file_uploader("Tabular CSV", type=["csv"], key="mm_tabular")
-        img_up = st.file_uploader("Image CSV", type=["csv"], key="mm_image")
-        sens_up = st.file_uploader("Sensor CSV", type=["csv"], key="mm_sensor")
-
-        if tab_up is not None:
-            tab_df = pd.read_csv(tab_up)
-            st.session_state["mm_tabular_df"] = tab_df
-            st.dataframe(tab_df.head(), use_container_width=True)
-        if img_up is not None:
-            img_df = pd.read_csv(img_up)
-            st.session_state["mm_image_df"] = img_df
-            st.dataframe(img_df.head(), use_container_width=True)
-        if sens_up is not None:
-            sens_df = pd.read_csv(sens_up)
-            st.session_state["mm_sensor_df"] = sens_df
-            st.dataframe(sens_df.head(), use_container_width=True)
-
-        has_any = any(
-            k in st.session_state for k in ["mm_tabular_df", "mm_image_df", "mm_sensor_df"]
+        mode = st.radio(
+            "Choose upload mode",
+            ("Processed feature CSVs", "Raw assets (ZIP + manifest)"),
+            key="mm_upload_mode",
+            horizontal=True,
         )
-        if has_any:
-            st.markdown("### Field Alignment")
-            tab_id = img_id = sens_id = None
-            if "mm_tabular_df" in st.session_state:
-                tab_id = st.selectbox(
-                    "Tabular ID column",
-                    st.session_state["mm_tabular_df"].columns,
-                    key="mm_tab_id",
-                )
-            if "mm_image_df" in st.session_state:
-                img_id = st.selectbox(
-                    "Image ID column",
-                    st.session_state["mm_image_df"].columns,
-                    key="mm_img_id",
-                )
-            if "mm_sensor_df" in st.session_state:
-                sens_id = st.selectbox(
-                    "Sensor ID column",
-                    st.session_state["mm_sensor_df"].columns,
-                    key="mm_sens_id",
-                )
 
-            if st.button("Load Multimodal Data"):
-                combined = st.session_state.get("mm_tabular_df")
-                if combined is None:
-                    st.warning("Tabular data is required for alignment.")
-                else:
-                    if "mm_image_df" in st.session_state and img_id:
-                        combined = combined.merge(
-                            st.session_state["mm_image_df"],
-                            left_on=tab_id,
-                            right_on=img_id,
-                            how="left",
-                        )
-                    if "mm_sensor_df" in st.session_state and sens_id:
-                        combined = combined.merge(
-                            st.session_state["mm_sensor_df"],
-                            left_on=tab_id,
-                            right_on=sens_id,
-                            how="left",
-                        )
+        if mode == "Processed feature CSVs":
+            tab_up = st.file_uploader("Tabular CSV", type=["csv"], key="mm_tabular")
+            img_up = st.file_uploader("Image CSV", type=["csv"], key="mm_image")
+            sens_up = st.file_uploader("Sensor CSV", type=["csv"], key="mm_sensor")
 
-                    st.session_state["clinical_data"] = combined
-                    if "data_manager" in st.session_state:
-                        dm = st.session_state.data_manager
-                        dm.load_multimodal_data(
-                            tabular_df=st.session_state.get("mm_tabular_df"),
-                            image_df=st.session_state.get("mm_image_df"),
-                            sensor_df=st.session_state.get("mm_sensor_df"),
-                        )
-                        dm.load_data(combined, "multimodal_combined")
-                    st.success(
-                        f"✅ Loaded multimodal data ({combined.shape[0]} rows × {combined.shape[1]} columns)"
+            if tab_up is not None:
+                tab_df = pd.read_csv(tab_up)
+                st.session_state["mm_tabular_df"] = tab_df
+                st.dataframe(tab_df.head(), use_container_width=True)
+            if img_up is not None:
+                img_df = pd.read_csv(img_up)
+                st.session_state["mm_image_df"] = img_df
+                st.dataframe(img_df.head(), use_container_width=True)
+            if sens_up is not None:
+                sens_df = pd.read_csv(sens_up)
+                st.session_state["mm_sensor_df"] = sens_df
+                st.dataframe(sens_df.head(), use_container_width=True)
+
+            has_any = any(
+                st.session_state.get(k) is not None for k in ["mm_tabular_df", "mm_image_df", "mm_sensor_df"]
+            )
+            if has_any:
+                st.markdown("### Field Alignment")
+                tab_id = img_id = sens_id = None
+                if "mm_tabular_df" in st.session_state:
+                    tab_id = st.selectbox(
+                        "Tabular ID column",
+                        st.session_state["mm_tabular_df"].columns,
+                        key="mm_tab_id",
                     )
-                    st.dataframe(combined.head(), use_container_width=True)
+                if "mm_image_df" in st.session_state:
+                    img_id = st.selectbox(
+                        "Image ID column",
+                        st.session_state["mm_image_df"].columns,
+                        key="mm_img_id",
+                    )
+                if "mm_sensor_df" in st.session_state:
+                    sens_id = st.selectbox(
+                        "Sensor ID column",
+                        st.session_state["mm_sensor_df"].columns,
+                        key="mm_sens_id",
+                    )
+
+                if st.button("Load Multimodal Data", key="mm_load_processed"):
+                    combined = st.session_state.get("mm_tabular_df")
+                    if combined is None:
+                        st.warning("Tabular data is required for alignment.")
+                    else:
+                        if "mm_image_df" in st.session_state and img_id:
+                            combined = combined.merge(
+                                st.session_state["mm_image_df"],
+                                left_on=tab_id,
+                                right_on=img_id,
+                                how="left",
+                            )
+                        if "mm_sensor_df" in st.session_state and sens_id:
+                            combined = combined.merge(
+                                st.session_state["mm_sensor_df"],
+                                left_on=tab_id,
+                                right_on=sens_id,
+                                how="left",
+                            )
+
+                        st.session_state["clinical_data"] = combined
+                        if "data_manager" in st.session_state:
+                            dm = st.session_state.data_manager
+                            dm.load_multimodal_data(
+                                tabular_df=st.session_state.get("mm_tabular_df"),
+                                image_df=st.session_state.get("mm_image_df"),
+                                sensor_df=st.session_state.get("mm_sensor_df"),
+                            )
+                            dm.load_data(combined, "multimodal_combined")
+                        st.success(
+                            f"✅ Loaded multimodal data ({combined.shape[0]} rows × {combined.shape[1]} columns)"
+                        )
+                        st.dataframe(combined.head(), use_container_width=True)
+        else:
+            st.markdown(
+                "Upload the raw assets (ZIP + manifest) exported by the simulator or your own pipeline."
+            )
+            tab_up = st.file_uploader("Tabular CSV (required)", type=["csv"], key="mm_raw_tabular")
+            id_col = st.text_input(
+                "Common ID column for alignment",
+                value=st.session_state.get("mm_raw_id_col", "id"),
+                key="mm_raw_id_col",
+            )
+            img_id_col = st.text_input(
+                "Image manifest ID column",
+                value=st.session_state.get("mm_raw_img_id_col", "id"),
+                key="mm_raw_img_id_col",
+            )
+            sens_id_col = st.text_input(
+                "Sensor manifest ID column",
+                value=st.session_state.get("mm_raw_sens_id_col", "id"),
+                key="mm_raw_sens_id_col",
+            )
+
+            c1, c2 = st.columns(2)
+            with c1:
+                img_zip = st.file_uploader("Image ZIP", type=["zip"], key="mm_raw_img_zip")
+                img_manifest = st.file_uploader("Image manifest CSV", type=["csv"], key="mm_raw_img_manifest")
+                img_bs = st.number_input(
+                    "Image batch size",
+                    min_value=8,
+                    max_value=256,
+                    value=int(st.session_state.get("mm_raw_img_bs", 32)),
+                    step=8,
+                    key="mm_raw_img_bs",
+                )
+            with c2:
+                sens_zip = st.file_uploader("Sensor ZIP", type=["zip"], key="mm_raw_sensor_zip")
+                sens_manifest = st.file_uploader(
+                    "Sensor manifest CSV",
+                    type=["csv"],
+                    key="mm_raw_sensor_manifest",
+                )
+                sens_resample = st.number_input(
+                    "Sensor resample Hz (0 = no resample)",
+                    min_value=0,
+                    max_value=256,
+                    value=int(st.session_state.get("mm_raw_sensor_resample", 0)),
+                    step=1,
+                    key="mm_raw_sensor_resample",
+                )
+                sens_max_rows = st.number_input(
+                    "Max rows per sensor file (0 = all)",
+                    min_value=0,
+                    max_value=2_000_000,
+                    value=int(st.session_state.get("mm_raw_sensor_maxrows", 0)),
+                    step=1000,
+                    key="mm_raw_sensor_maxrows",
+                )
+
+            if st.button("Process Raw Multimodal Assets", key="mm_process_raw"):
+                if tab_up is None:
+                    st.warning("Please upload the tabular CSV before processing raw assets.")
+                    st.stop()
+
+                try:
+                    tab_df = pd.read_csv(tab_up)
+                    tab_df.columns = [str(c).strip() for c in tab_df.columns]
+                except Exception as exc:
+                    st.error(f"Failed to read tabular CSV: {exc}")
+                    st.stop()
+
+                if id_col not in tab_df.columns:
+                    st.error(f"Tabular CSV must contain the ID column '{id_col}'.")
+                    st.stop()
+
+                tab_df[id_col] = tab_df[id_col].astype(str)
+
+                st.session_state["mm_image_df"] = None
+                st.session_state["mm_sensor_df"] = None
+
+                image_df = None
+                if img_zip is not None and img_manifest is not None:
+                    try:
+                        img_manifest_df = pd.read_csv(img_manifest)
+                        img_manifest_df.columns = [str(c).strip() for c in img_manifest_df.columns]
+                        if img_id_col not in img_manifest_df.columns:
+                            raise KeyError(f"Image manifest is missing column '{img_id_col}'.")
+                        with st.spinner("Extracting image embeddings..."):
+                            img_root = unzip_images_to_temp(img_zip)
+                            image_df = images_to_dataframe(
+                                img_manifest_df,
+                                image_root=img_root,
+                                id_col=img_id_col,
+                                batch_size=int(img_bs),
+                                num_workers=0,
+                            )
+                        if img_id_col != id_col and image_df is not None and img_id_col in image_df.columns:
+                            image_df = image_df.rename(columns={img_id_col: id_col})
+                        if image_df is not None and id_col in image_df.columns:
+                            image_df[id_col] = image_df[id_col].astype(str)
+                        st.session_state["mm_image_df"] = image_df
+                        st.dataframe(image_df.head(), use_container_width=True)
+                    except Exception as exc:
+                        st.error(f"Image processing failed: {exc}")
+                        image_df = None
+
+                sensor_df = None
+                if sens_zip is not None and sens_manifest is not None:
+                    try:
+                        sens_manifest_df = pd.read_csv(sens_manifest)
+                        sens_manifest_df.columns = [str(c).strip() for c in sens_manifest_df.columns]
+                        if sens_id_col not in sens_manifest_df.columns:
+                            raise KeyError(f"Sensor manifest is missing column '{sens_id_col}'.")
+                        with st.spinner("Extracting sensor features..."):
+                            sens_root = unzip_sensors_to_temp(sens_zip)
+                            sensor_df = sensors_to_dataframe(
+                                sens_manifest_df,
+                                sensor_root=sens_root,
+                                id_col=sens_id_col,
+                                resample_hz=float(sens_resample),
+                                max_rows_per_file=int(sens_max_rows),
+                            )
+                        if sens_id_col != id_col and sensor_df is not None and sens_id_col in sensor_df.columns:
+                            sensor_df = sensor_df.rename(columns={sens_id_col: id_col})
+                        if sensor_df is not None and id_col in sensor_df.columns:
+                            sensor_df[id_col] = sensor_df[id_col].astype(str)
+                        st.session_state["mm_sensor_df"] = sensor_df
+                        st.dataframe(sensor_df.head(), use_container_width=True)
+                    except Exception as exc:
+                        st.error(f"Sensor processing failed: {exc}")
+                        sensor_df = None
+
+                st.session_state["mm_tabular_df"] = tab_df
+
+                combined = tab_df.copy()
+                if image_df is not None and id_col in image_df.columns:
+                    combined = combined.merge(image_df, on=id_col, how="left")
+                if sensor_df is not None and id_col in sensor_df.columns:
+                    combined = combined.merge(sensor_df, on=id_col, how="left")
+
+                st.session_state["clinical_data"] = combined
+                st.session_state["mm_tab_id"] = id_col
+
+                if "data_manager" in st.session_state:
+                    dm = st.session_state.data_manager
+                    dm.load_multimodal_data(
+                        tabular_df=tab_df,
+                        image_df=image_df,
+                        sensor_df=sensor_df,
+                    )
+                    dm.load_data(combined, "multimodal_combined_raw")
+
+                st.success(
+                    f"✅ Processed raw multimodal assets ({combined.shape[0]} rows × {combined.shape[1]} columns)"
+                )
+                st.dataframe(combined.head(), use_container_width=True)
 
     # ===================== 1) Data upload & preview ===========================
     with st.expander("📘 Step-by-Step Guide for Tabular Data", expanded=False):
@@ -1030,11 +1246,25 @@ def show():
             )
 
 
+    mm_tab_id = None
+    if any(st.session_state.get(k) is not None for k in ["mm_image_df", "mm_sensor_df"]):
+        mm_tab_id = st.session_state.get("mm_tab_id")
+        if mm_tab_id and mm_tab_id in features:
+            features = [f for f in features if f != mm_tab_id]
+
+
     # Build working dataframe with required names
     try:
         # 先取用户选择的列并规范列名
-        base = data[features + [time_col, event_col]].copy()
+        base_cols = features + [time_col, event_col]
+        if mm_tab_id and mm_tab_id not in base_cols:
+            base_cols.append(mm_tab_id)
+        base = data[base_cols].copy()
         df = base.rename(columns={time_col: "duration", event_col: "event"})
+
+        id_series = None
+        if mm_tab_id and mm_tab_id in df.columns:
+            id_series = df[mm_tab_id].copy()
 
         # 事件列映射为 0/1（保持你原有的正类映射逻辑）
         df["event"] = _ensure_binary_event(
@@ -1110,7 +1340,12 @@ def show():
                 X = (X - mu) / sigma
 
             # 5) 组装回最终训练表（duration,event + 纯数值特征）
-            df = _pd.concat([df[["duration","event"]], X.astype("float32")], axis=1)
+            parts = []
+            if id_series is not None:
+                parts.append(id_series.to_frame(name=mm_tab_id))
+            parts.append(df[["duration", "event"]])
+            parts.append(X.astype("float32"))
+            df = _pd.concat(parts, axis=1)
 
             # 同步“特征列列表”供后续 config 使用
             features = list(X.columns)
@@ -1440,6 +1675,10 @@ def run_analysis(algo: str, df: pd.DataFrame, config: dict):
     elif "texgisa" in algo or "mysa" in algo:
         if run_texgisa is None:
             raise RuntimeError("TEXGISA not available. Please ensure models/mysa.py is present.")
-        return run_texgisa(df, config)
+        cfg = dict(config)
+        mm_sources = _build_multimodal_sources(cfg)
+        if mm_sources is not None:
+            cfg["multimodal_sources"] = mm_sources
+        return run_texgisa(df, cfg)
     else:
         raise ValueError(f"Unknown algorithm: {algo}")

--- a/sa_data_manager.py
+++ b/sa_data_manager.py
@@ -47,18 +47,23 @@ class DataManager:
         self.image_df = image_df
         self.sensor_df = sensor_df
 
-        # Preserve backward compatibility: expose the first available DataFrame
-        # as ``_data`` so that existing calls to ``get_data`` keep working.
-        primary = tabular_df or image_df or sensor_df
-        if primary is not None:
-            self._data = primary
+        # Preserve backward compatibility: expose the first available
+        # DataFrame as ``_data`` so that existing calls to ``get_data`` keep
+        # working.  Explicitly test against ``None`` to avoid pandas truth
+        # value errors.
+        for candidate in (tabular_df, image_df, sensor_df):
+            if candidate is not None:
+                self._data = candidate
+                break
             # ``load_multimodal_data`` may not have a meaningful file name, so
             # we keep the previous one unless a new dataset is provided via
             # ``load_data``.
 
     def get_data_summary(self) -> dict:
         """Returns a summary of the loaded data."""
-        if self._data is None and not any([self.tabular_df, self.image_df, self.sensor_df]):
+        if self._data is None and not any(
+            df is not None for df in (self.tabular_df, self.image_df, self.sensor_df)
+        ):
             return {"error": "No data has been loaded. Please upload a dataset on the 'Run Models' page."}
 
         summary = {}

--- a/simulate_multimodal_data.py
+++ b/simulate_multimodal_data.py
@@ -1,0 +1,254 @@
+"""Generate a full multimodal toy dataset for local MySA experiments.
+
+The script writes a directory (``--output``) containing artefacts ready for the
+Streamlit workbench:
+
+* ``tabular.csv`` – core clinical table with ``id``, ``duration`` and ``event``.
+* ``image.csv`` – pre-computed embedding features keyed by ``id``.
+* ``sensor.csv`` – aggregated sensor statistics keyed by ``id``.
+* ``images/`` – RGB PNG files, plus ``image_manifest.csv`` for the image wizard.
+* ``sensor_sequences/`` – per-subject time-series CSVs, plus
+  ``sensor_manifest.csv`` and a zipped bundle ``sensor_sequences.zip`` for the
+  sensor wizard.
+
+Example::
+
+    python simulate_multimodal_data.py --samples 200 --seed 13
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import numpy as np
+import pandas as pd
+from pathlib import Path
+from typing import Tuple
+import zipfile
+
+try:  # Pillow is only needed when actually writing image files.
+    from PIL import Image
+except Exception as exc:  # pragma: no cover - CLI guard
+    raise RuntimeError(
+        "Pillow is required to generate synthetic image files. "
+        "Install it via `pip install pillow`."
+    ) from exc
+
+
+def make_tabular(ids: pd.Series, rng: np.random.Generator) -> pd.DataFrame:
+    n = len(ids)
+    age = rng.normal(62, 10, size=n)
+    bmi = rng.normal(26, 4, size=n)
+    systolic_bp = rng.normal(130, 15, size=n)
+    cholesterol = rng.normal(190, 35, size=n)
+    diabetes = rng.binomial(1, 0.25, size=n)
+
+    # survival labels
+    baseline_hazard = 0.03 + 0.002 * (age - 60) + 0.003 * diabetes
+    durations = rng.exponential(scale=1.0 / np.clip(baseline_hazard, 1e-3, None))
+    durations = np.clip(durations, 0.1, None)
+    censoring = rng.exponential(scale=20.0, size=n)
+    observed = np.minimum(durations, censoring)
+    events = (durations <= censoring).astype(int)
+
+    return pd.DataFrame(
+        {
+            "id": ids,
+            "duration": observed.round(2),
+            "event": events,
+            "age": age,
+            "bmi": bmi,
+            "systolic_bp": systolic_bp,
+            "cholesterol": cholesterol,
+            "diabetes": diabetes,
+        }
+    )
+
+
+def _make_rgb_image(
+    base_mean: float,
+    rng: np.random.Generator,
+    image_size: Tuple[int, int],
+) -> np.ndarray:
+    h, w = image_size
+    pattern = rng.normal(loc=base_mean, scale=0.08, size=(h, w, 3))
+    # Add a smooth radial gradient so that embeddings vary smoothly with base_mean.
+    yy, xx = np.meshgrid(np.linspace(-1, 1, h), np.linspace(-1, 1, w), indexing="ij")
+    radius = np.sqrt(xx**2 + yy**2)
+    pattern += 0.15 * np.cos(3 * math.pi * radius)[..., None]
+    pattern = np.clip(pattern, 0.0, 1.0)
+    return (pattern * 255).astype(np.uint8)
+
+
+def make_image_assets(
+    tabular: pd.DataFrame,
+    rng: np.random.Generator,
+    out_dir: Path,
+    *,
+    image_dim: int,
+    image_size: Tuple[int, int],
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Create synthetic PNG files and deterministic embeddings."""
+
+    img_dir = out_dir / "images"
+    img_dir.mkdir(parents=True, exist_ok=True)
+
+    h, w = image_size
+    # Global random projection to derive embeddings reproducibly from raw pixels.
+    proj = rng.normal(0, 1, size=(image_dim, h * w * 3))
+
+    feat_rows = []
+    manifest_rows = []
+
+    for row in tabular.itertuples(index=False):
+        base_mean = 0.45 + 0.002 * (float(row.age) - 60.0) + 0.05 * float(row.diabetes)
+        arr = _make_rgb_image(base_mean, rng, image_size)
+        fname = f"{row.id}.png"
+        Image.fromarray(arr).save(img_dir / fname)
+
+        flat = arr.astype(np.float32).reshape(-1) / 255.0
+        embedding = proj @ flat
+        feat_rows.append([row.id, *embedding.tolist()])
+        manifest_rows.append(
+            {
+                "id": row.id,
+                "image": f"images/{fname}",
+                "duration": row.duration,
+                "event": row.event,
+            }
+        )
+
+    cols = ["id"] + [f"img_feat_{i:03d}" for i in range(image_dim)]
+    feat_df = pd.DataFrame(feat_rows, columns=cols)
+    manifest_df = pd.DataFrame(manifest_rows)
+    return feat_df, manifest_df
+
+
+def make_sensor_assets(
+    tabular: pd.DataFrame,
+    rng: np.random.Generator,
+    out_dir: Path,
+    *,
+    sequence_length: int,
+    sampling_rate: float,
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Create synthetic sensor sequences + aggregated statistics."""
+
+    sens_dir = out_dir / "sensor_sequences"
+    sens_dir.mkdir(parents=True, exist_ok=True)
+
+    time = np.arange(sequence_length) / max(sampling_rate, 1.0)
+
+    feat_rows = []
+    manifest_rows = []
+
+    for row in tabular.itertuples(index=False):
+        base_hr = 72 + 6 * float(row.diabetes) + 0.2 * (float(row.bmi) - 25)
+        hr = base_hr + 3 * np.sin(2 * np.pi * time / 24) + rng.normal(0, 2, size=sequence_length)
+
+        activity = rng.normal(0, 1, size=(sequence_length, 3))
+        # Modulate activity by age (older → lower magnitude) and event occurrence (event → more variation).
+        activity *= 1.2 - 0.004 * (float(row.age) - 60)
+        if int(row.event) == 1:
+            activity += rng.normal(0, 0.5, size=(sequence_length, 3))
+
+        steps = np.maximum(0.0, rng.normal(0.6, 0.2, size=sequence_length))
+        sleep = np.clip(
+            7.5 - 0.03 * (float(row.bmi) - 25) - 0.5 * float(row.diabetes) + rng.normal(0, 0.3),
+            4.5,
+            9.0,
+        )
+
+        seq_df = pd.DataFrame(
+            {
+                "time": time,
+                "accel_x": activity[:, 0],
+                "accel_y": activity[:, 1],
+                "accel_z": activity[:, 2],
+                "heart_rate": hr,
+                "step_rate": steps,
+            }
+        )
+        fname = f"{row.id}.csv"
+        seq_df.to_csv(sens_dir / fname, index=False)
+
+        accel_mag = np.linalg.norm(activity, axis=1)
+        feat_rows.append(
+            {
+                "id": row.id,
+                "accel_mean": float(np.mean(accel_mag)),
+                "accel_std": float(np.std(accel_mag, ddof=0)),
+                "hr_mean": float(np.mean(hr)),
+                "hr_std": float(np.std(hr, ddof=0)),
+                "step_count": float(np.sum(steps) * (24 / sequence_length)),
+                "sleep_hours": float(sleep),
+            }
+        )
+        manifest_rows.append(
+            {
+                "id": row.id,
+                "file": f"sensor_sequences/{fname}",
+                "duration": row.duration,
+                "event": row.event,
+            }
+        )
+
+    feat_df = pd.DataFrame(feat_rows)
+    manifest_df = pd.DataFrame(manifest_rows)
+    return feat_df, manifest_df
+
+
+def main(args: argparse.Namespace) -> None:
+    rng = np.random.default_rng(args.seed)
+    ids = pd.Series([f"PT_{i:04d}" for i in range(args.samples)], name="id")
+
+    out_dir = Path(args.output)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    tab = make_tabular(ids, rng)
+    img_feats, img_manifest = make_image_assets(
+        tab,
+        rng,
+        out_dir,
+        image_dim=args.image_dim,
+        image_size=(args.image_size, args.image_size),
+    )
+    sens_feats, sens_manifest = make_sensor_assets(
+        tab,
+        rng,
+        out_dir,
+        sequence_length=args.sensor_length,
+        sampling_rate=args.sensor_rate,
+    )
+
+    tab.to_csv(out_dir / "tabular.csv", index=False)
+    img_feats.to_csv(out_dir / "image.csv", index=False)
+    sens_feats.to_csv(out_dir / "sensor.csv", index=False)
+    img_manifest.to_csv(out_dir / "image_manifest.csv", index=False)
+    sens_manifest.to_csv(out_dir / "sensor_manifest.csv", index=False)
+
+    # Also ship a zipped version of the sensor sequences for convenience.
+    zip_path = out_dir / "sensor_sequences.zip"
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for csv_path in (out_dir / "sensor_sequences").glob("*.csv"):
+            zf.write(csv_path, arcname=csv_path.name)
+
+    print(f"Saved tabular data to {out_dir / 'tabular.csv'}")
+    print(f"Saved image embeddings to {out_dir / 'image.csv'} (raw files in images/)")
+    print(
+        "Saved sensor features to {0} (time-series in sensor_sequences/ and zipped at {1})"
+        .format(out_dir / "sensor.csv", zip_path)
+    )
+    print(f"Image manifest written to {out_dir / 'image_manifest.csv'}")
+    print(f"Sensor manifest written to {out_dir / 'sensor_manifest.csv'}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate synthetic multimodal survival data for MySA testing.")
+    parser.add_argument("--samples", type=int, default=200, help="Number of patients to simulate")
+    parser.add_argument("--image-dim", type=int, default=128, help="Dimensionality of simulated image embeddings")
+    parser.add_argument("--image-size", type=int, default=64, help="Height/width of generated square images in pixels")
+    parser.add_argument("--sensor-length", type=int, default=512, help="Number of timesteps per synthetic sensor recording")
+    parser.add_argument("--sensor-rate", type=float, default=1.0, help="Sampling rate (Hz) for synthetic sensors")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed")
+    parser.add_argument("--output", type=str, default="synthetic_multimodal", help="Output directory")
+    main(parser.parse_args())


### PR DESCRIPTION
## Summary
- add ID preservation to the image and sensor feature extractors so multimodal tables align on shared identifiers
- extend the Streamlit "Multimodal Data Upload" panel with a raw-asset mode that accepts ZIP archives plus manifests and pipes them through the encoders before merging
- harden the data manager's multimodal loader against pandas truth-value errors when only some modalities are provided

## Testing
- python -m compileall sa_data_manager.py pages_logic/run_models.py image_pipeline.py sensor_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e95d97f39c832b93267ebc0a03dd71