### PR TITLE
Normalize numeric ID canonicalization for multimodal merges

### DIFF
--- a/utils/identifiers.py
+++ b/utils/identifiers.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import math
+import re
 from typing import Any, Optional
 
 import numpy as np
@@ -46,7 +47,16 @@ def canonicalize_identifier(value: Any) -> Optional[str]:
             return str(int(fv))
         return format(fv, "g")
 
+    if _NUMERIC_STRING_PATTERN.fullmatch(text):
+        try:
+            return str(int(text))
+        except ValueError:
+            return text
+
     return text
+
+
+_NUMERIC_STRING_PATTERN = re.compile(r"[+-]?[0-9]+")
 
 
 def canonicalize_series(series: pd.Series) -> pd.Series:

--- a/utils/test_identifiers.py
+++ b/utils/test_identifiers.py
@@ -1,0 +1,28 @@
+import pytest
+
+from utils.identifiers import canonicalize_identifier
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("001", "1"),
+        ("000123", "123"),
+        ("-0005", "-5"),
+        ("+0008", "8"),
+    ],
+)
+def test_canonicalize_identifier_normalizes_numeric_strings(value, expected):
+    assert canonicalize_identifier(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("abc", "abc"),
+        ("001abc", "001abc"),
+        ("0.010", "0.01"),
+    ],
+)
+def test_canonicalize_identifier_preserves_non_integer_strings(value, expected):
+    assert canonicalize_identifier(value) == expected


### PR DESCRIPTION
## Summary
- normalize the identifier canonicalization helper so that purely numeric strings are converted to their integer form for consistent alignment across modalities
- add regression tests ensuring numeric strings are normalized while non-numeric identifiers are preserved

## Testing
- pytest utils/test_identifiers.py

------
https://chatgpt.com/codex/tasks/task_e_68effee83038832b81df07fa8d39b1ba