### PR TITLE
Clarify multimodal workflow and TEXGISA routing

### DIFF
--- a/pages_logic/run_models.py
+++ b/pages_logic/run_models.py
@@ -140,7 +140,7 @@ def _qhelp_md(key: str) -> str:
         "positive_label": "Maps samples in the event column equal to this value to 1 (event occurred), and all others to 0 (censored).",
 
         # Algorithm Selection & Common Training Parameters
-        "algo":           "Select the training algorithm. TEXGISA supports time-dependent explanations and expert priors; CoxTime/DeepSurv/DeepHit are common baselines.",
+        "algo":           "Select the training algorithm. TEXGISA is the only option that performs end-to-end multimodal training (tabular + raw images/sensors) with TEXGI explanations. CoxTime/DeepSurv/DeepHit consume tabular inputs or pre-fused feature tables only.",
         "batch_size":     "The number of samples used for each parameter update. Can be reduced if GPU memory is tight; more stable but slower.",
         "epochs":         "The number of training epochs. A larger value is generally more stable but takes longer. It's recommended to start with 50~150 to observe convergence.",
         "lr":             "Learning rate. Too large can cause oscillations, too small makes training very slow. You can start with a range of 1e-3 ~ 1e-2.",
@@ -194,6 +194,76 @@ def field_with_help(control_fn, label, help_key: str, *args, **kwargs):
                 if st.button("❔", key=f"help_{help_key}"):
                     st.info(help_msg)
         return val
+
+
+def _render_help_popover(text: str, key: str):
+    """Render a small ❔ button that reveals explanatory Markdown when clicked."""
+    try:
+        with st.popover("❔", key=key):
+            st.markdown(text)
+    except Exception:
+        # Streamlit versions without popover fall back to a plain button that
+        # appends the explanation inline.
+        if st.button("❔", key=f"{key}_btn"):
+            st.info(text)
+
+
+def uploader_with_help(label: str, *, key: str, help_text: str, column_ratio: Sequence[float] | None = None, **kwargs):
+    """Wrap ``st.file_uploader`` with a trailing ❔ help button."""
+    if column_ratio is None:
+        column_ratio = (0.9, 0.1)
+    cols = st.columns(column_ratio)
+    with cols[0]:
+        widget = st.file_uploader(label, key=key, **kwargs)
+    with cols[1]:
+        _render_help_popover(help_text, f"{key}_help")
+    return widget
+
+
+CHANNEL_HELP_TEXT: Dict[str, str] = {
+    "tabular_csv": (
+        "Upload a tabular survival dataset (CSV) with one row per subject, including `duration`/`event` columns. "
+        "All algorithms can train on this table. Add a stable identifier column if you plan to align extra modalities."
+    ),
+    "img_zip_simple": (
+        "Compressed folder (.zip) containing one image per subject. The wizard will extract features and build a table. "
+        "Only TEXGISA can later train end-to-end on raw images; other algorithms consume the generated tabular features."
+    ),
+    "img_labels_csv": (
+        "CSV template for image labels. Provide columns `image`, `duration`, and `event` so survival metrics can be derived."
+    ),
+    "sensor_zip": (
+        "Compressed folder (.zip) with sensor files (CSV/Parquet) per subject. Ensure filenames map to individuals consistently. "
+        "End-to-end multimodal training requires TEXGISA; other algorithms will use any derived feature table instead."
+    ),
+    "sensor_labels_csv": (
+        "CSV with `file`, `duration`, and `event` columns describing outcomes for each sensor recording."
+    ),
+    "mm_tabular": (
+        "Processed tabular modality aligned by ID. Works for every algorithm and acts as the anchor when merging other modalities."
+    ),
+    "mm_image": (
+        "Image-level features or metadata keyed by the same identifier as the tabular table. TEXGISA is required for end-to-end multimodal learning."
+    ),
+    "mm_sensor": (
+        "Sensor feature table keyed by the shared identifier. Non-TEXGISA algorithms will treat these as pre-merged columns."
+    ),
+    "mm_raw_tabular": (
+        "Primary tabular CSV used to align raw assets. Must contain the shared identifier, duration, and event columns."
+    ),
+    "mm_raw_img_zip": (
+        "Zip archive with raw image files referenced by the image manifest. Required for TEXGISA end-to-end multimodal runs."
+    ),
+    "mm_raw_img_manifest": (
+        "CSV manifest that lists each image filename alongside the shared identifier so TEXGISA can stream the raw assets."
+    ),
+    "mm_raw_sensor_zip": (
+        "Zip archive with raw sensor files. TEXGISA consumes these during joint multimodal optimisation."
+    ),
+    "mm_raw_sensor_manifest": (
+        "CSV manifest describing sensor files (`file`, shared ID, optional metadata) for TEXGISA's multimodal loader."
+    ),
+}
 
 
 def _extract_fi_df(results: dict) -> pd.DataFrame | None:
@@ -750,11 +820,17 @@ def show():
     with st.expander("🖼️ Build Training Data from Image Data (ResNet-50 → Features)", expanded=False):
         st.markdown(
             "Steps: Upload **Image ZIP** → Complete/Import **Survival Labels** → One-click generate data table and directly train TEXGISA.\n\n"
-            "**Label Definitions**: `duration` is the follow-up time, `event` indicates if the event occurred (0=No, 1=Yes)."
+            "**Label Definitions**: `duration` is the follow-up time, `event` indicates if the event occurred (0=No, 1=Yes).\n\n"
+            "**Multimodal note**: Only TEXGISA consumes the raw images for end-to-end multimodal optimisation; other algorithms will use the generated tabular feature table."
         )
 
         # 1) Upload ZIP (Required)
-        zip_up = st.file_uploader("① Upload Image ZIP (Required)", type=["zip"], key="img_zip_simple")
+        zip_up = uploader_with_help(
+            "① Upload Image ZIP (Required)",
+            key="img_zip_simple",
+            help_text=CHANNEL_HELP_TEXT["img_zip_simple"],
+            type=["zip"],
+        )
 
         # 2) Parse ZIP and generate manifest (no path concept)
         if "imgwiz_manifest" not in st.session_state:
@@ -788,7 +864,12 @@ def show():
                     help="The template includes all image filenames. Please fill in the values in the duration/event columns."
                 )
             with c2:
-                labels_up = st.file_uploader("Or upload your completed label CSV", type=["csv"], key="img_labels_csv")
+                labels_up = uploader_with_help(
+                    "Or upload your completed label CSV",
+                    key="img_labels_csv",
+                    help_text=CHANNEL_HELP_TEXT["img_labels_csv"],
+                    type=["csv"],
+                )
 
             # If a label CSV is uploaded, merge it automatically
             if labels_up is not None:
@@ -907,10 +988,16 @@ def show():
         st.markdown(
             "Steps: Upload **Sensor ZIP** (one file per sample, CSV/Parquet) → Complete/Import `file,duration,event` → "
             "Extract **full-sequence features** at once → Generate training table and directly train TEXGISA.\n\n"
-            "**Note**: By default, statistical and frequency-domain features are extracted from the entire sequence without a sliding window. If files contain timestamps, you can select a resampling frequency."
+            "**Note**: By default, statistical and frequency-domain features are extracted from the entire sequence without a sliding window. If files contain timestamps, you can select a resampling frequency.\n\n"
+            "**Multimodal note**: End-to-end optimisation on raw sensor waveforms is exclusive to TEXGISA; other algorithms will consume only the generated tabular features."
         )
 
-        zip_up_sens = st.file_uploader("① Upload Sensor ZIP (Required)", type=["zip"], key="sensor_zip")
+        zip_up_sens = uploader_with_help(
+            "① Upload Sensor ZIP (Required)",
+            key="sensor_zip",
+            help_text=CHANNEL_HELP_TEXT["sensor_zip"],
+            type=["zip"],
+        )
         if "senswiz_manifest" not in st.session_state:
             st.session_state["senswiz_manifest"] = None
             st.session_state["senswiz_root"] = ""
@@ -941,7 +1028,12 @@ def show():
                     mime="text/csv",
                 )
             with cc2:
-                labels_up = st.file_uploader("Upload Your Completed Label CSV", type=["csv"], key="sensor_labels_csv")
+                labels_up = uploader_with_help(
+                    "Upload Your Completed Label CSV",
+                    key="sensor_labels_csv",
+                    help_text=CHANNEL_HELP_TEXT["sensor_labels_csv"],
+                    type=["csv"],
+                )
 
             # Merge label CSV
             if labels_up is not None:
@@ -1027,6 +1119,10 @@ def show():
 
     # ===================== Multimodal data upload =============================
     with st.expander("🗂 Multimodal Data Upload", expanded=False):
+        st.info(
+            "TEXGISA is the only algorithm that performs end-to-end multimodal training. "
+            "CoxTime, DeepSurv, and DeepHit will rely on the merged tabular table created in this section."
+        )
         mode = st.radio(
             "Choose upload mode",
             ("Processed feature CSVs", "Raw assets (ZIP + manifest)"),
@@ -1035,9 +1131,24 @@ def show():
         )
 
         if mode == "Processed feature CSVs":
-            tab_up = st.file_uploader("Tabular CSV", type=["csv"], key="mm_tabular")
-            img_up = st.file_uploader("Image CSV", type=["csv"], key="mm_image")
-            sens_up = st.file_uploader("Sensor CSV", type=["csv"], key="mm_sensor")
+            tab_up = uploader_with_help(
+                "Tabular CSV",
+                key="mm_tabular",
+                help_text=CHANNEL_HELP_TEXT["mm_tabular"],
+                type=["csv"],
+            )
+            img_up = uploader_with_help(
+                "Image CSV",
+                key="mm_image",
+                help_text=CHANNEL_HELP_TEXT["mm_image"],
+                type=["csv"],
+            )
+            sens_up = uploader_with_help(
+                "Sensor CSV",
+                key="mm_sensor",
+                help_text=CHANNEL_HELP_TEXT["mm_sensor"],
+                type=["csv"],
+            )
 
             if tab_up is not None:
                 tab_df = pd.read_csv(tab_up)
@@ -1124,27 +1235,45 @@ def show():
             st.markdown(
                 "Upload the raw assets (ZIP + manifest) exported by the simulator or your own pipeline."
             )
-            tab_up = st.file_uploader("Tabular CSV (required)", type=["csv"], key="mm_raw_tabular")
+            tab_up = uploader_with_help(
+                "Tabular CSV (required)",
+                key="mm_raw_tabular",
+                help_text=CHANNEL_HELP_TEXT["mm_raw_tabular"],
+                type=["csv"],
+            )
             id_col = st.text_input(
                 "Common ID column for alignment",
                 value=st.session_state.get("mm_raw_id_col", "id"),
                 key="mm_raw_id_col",
+                help="Identifier present in every modality and used to align subjects across tables and manifests.",
             )
             img_id_col = st.text_input(
                 "Image manifest ID column",
                 value=st.session_state.get("mm_raw_img_id_col", "id"),
                 key="mm_raw_img_id_col",
+                help="Column name inside the image manifest that matches the shared identifier.",
             )
             sens_id_col = st.text_input(
                 "Sensor manifest ID column",
                 value=st.session_state.get("mm_raw_sens_id_col", "id"),
                 key="mm_raw_sens_id_col",
+                help="Column name inside the sensor manifest that matches the shared identifier.",
             )
 
             c1, c2 = st.columns(2)
             with c1:
-                img_zip = st.file_uploader("Image ZIP", type=["zip"], key="mm_raw_img_zip")
-                img_manifest = st.file_uploader("Image manifest CSV", type=["csv"], key="mm_raw_img_manifest")
+                img_zip = uploader_with_help(
+                    "Image ZIP",
+                    key="mm_raw_img_zip",
+                    help_text=CHANNEL_HELP_TEXT["mm_raw_img_zip"],
+                    type=["zip"],
+                )
+                img_manifest = uploader_with_help(
+                    "Image manifest CSV",
+                    key="mm_raw_img_manifest",
+                    help_text=CHANNEL_HELP_TEXT["mm_raw_img_manifest"],
+                    type=["csv"],
+                )
                 img_bs = st.number_input(
                     "Image batch size",
                     min_value=8,
@@ -1154,11 +1283,17 @@ def show():
                     key="mm_raw_img_bs",
                 )
             with c2:
-                sens_zip = st.file_uploader("Sensor ZIP", type=["zip"], key="mm_raw_sensor_zip")
-                sens_manifest = st.file_uploader(
+                sens_zip = uploader_with_help(
+                    "Sensor ZIP",
+                    key="mm_raw_sensor_zip",
+                    help_text=CHANNEL_HELP_TEXT["mm_raw_sensor_zip"],
+                    type=["zip"],
+                )
+                sens_manifest = uploader_with_help(
                     "Sensor manifest CSV",
-                    type=["csv"],
                     key="mm_raw_sensor_manifest",
+                    help_text=CHANNEL_HELP_TEXT["mm_raw_sensor_manifest"],
+                    type=["csv"],
                 )
                 sens_resample = st.number_input(
                     "Sensor resample Hz (0 = no resample)",
@@ -1340,7 +1475,12 @@ def show():
             "- For **TEXGISA**, you can set **λ_smooth** and **λ_expert**, and edit **Expert Rules**."
         )
 
-    uploaded = st.file_uploader("Upload CSV", type=["csv"])
+    uploaded = uploader_with_help(
+        "Upload CSV",
+        key="clinical_upload",
+        help_text=CHANNEL_HELP_TEXT["tabular_csv"],
+        type=["csv"],
+    )
     if uploaded is not None:
         try:
             data = pd.read_csv(uploaded)
@@ -1689,6 +1829,19 @@ def show():
         "feature_cols": features,
     })
 
+    mm_sources = _build_multimodal_sources(config)
+    if mm_sources:
+        if algo == "TEXGISA":
+            config["multimodal_sources"] = mm_sources
+            st.success(
+                "✅ Raw multimodal inputs detected. TEXGISA will optimise all modalities end-to-end with TEXGI."
+            )
+        else:
+            st.warning(
+                f"Raw multimodal inputs are loaded, but {algo} will ignore the raw assets and train on the merged table only. "
+                "Switch to TEXGISA for end-to-end multimodal optimisation."
+            )
+
     # ===================== 5) Run =============================================
     c_run1, c_run2 = st.columns(2)
     with c_run1:
@@ -1856,9 +2009,10 @@ def run_analysis(algo: str, df: pd.DataFrame, config: dict):
         if run_texgisa is None:
             raise RuntimeError("TEXGISA not available. Please ensure models/mysa.py is present.")
         cfg = dict(config)
-        mm_sources = _build_multimodal_sources(cfg)
-        if mm_sources is not None:
-            cfg["multimodal_sources"] = mm_sources
+        if "multimodal_sources" not in cfg:
+            mm_sources = _build_multimodal_sources(cfg)
+            if mm_sources is not None:
+                cfg["multimodal_sources"] = mm_sources
         return run_texgisa(df, cfg)
     else:
         raise ValueError(f"Unknown algorithm: {algo}")

--- a/update1015.md
+++ b/update1015.md
@@ -1,0 +1,13 @@
+# Update 2024-10-15
+
+## UI Enhancements
+- Added contextual ❔ help popovers to every data ingestion widget (tabular, image, sensor, and multimodal assets) so users know which files to prepare and which algorithms can consume them.
+- Clarified throughout the wizards that only TEXGISA offers end-to-end multimodal optimisation, while other algorithms rely on pre-fused tables.
+- Improved guidance for manifest ID fields and multimodal upload panels to reduce ambiguity and highlight required identifiers.
+
+## Algorithm Routing
+- Surfaced runtime feedback that automatically detects raw multimodal inputs, routes them to TEXGISA, and warns when other algorithms fall back to flat tables.
+- Ensured the configuration handed to TEXGISA consistently includes multimodal sources while other algorithms ignore raw assets to avoid mismatched expectations.
+
+## Documentation
+- Documented these adjustments for internal tracking in this `update1015.md` file.


### PR DESCRIPTION
## Summary
- add reusable ❔ popover helpers to every file upload control and document the TEXGISA-only multimodal pipeline throughout the wizards
- warn users when non-TEXGISA algorithms ignore raw modalities while automatically wiring multimodal sources into TEXGISA runs
- record the UI and routing improvements in update1015.md for internal tracking

## Testing
- python -m compileall pages_logic/run_models.py

------
https://chatgpt.com/codex/tasks/task_e_68f0056aa490832b8f3181bceb8c27dd