### PR TITLE
Convert help popovers to hover tooltips

### DIFF
--- a/update1015.md
+++ b/update1015.md
@@ -1,0 +1,13 @@
+# Update 2024-10-15
+
+## UI Enhancements
+- Added contextual ❔ hover tooltips to every data ingestion widget (tabular, image, sensor, and multimodal assets) so users know which files to prepare and which algorithms can consume them without disruptive popover clicks.
+- Clarified throughout the wizards that only TEXGISA offers end-to-end multimodal optimisation, while other algorithms rely on pre-fused tables.
+- Improved guidance for manifest ID fields and multimodal upload panels to reduce ambiguity and highlight required identifiers.
+
+## Algorithm Routing
+- Surfaced runtime feedback that automatically detects raw multimodal inputs, routes them to TEXGISA, and warns when other algorithms fall back to flat tables.
+- Ensured the configuration handed to TEXGISA consistently includes multimodal sources while other algorithms ignore raw assets to avoid mismatched expectations.
+
+## Documentation
+- Documented these adjustments for internal tracking in this `update1015.md` file.


### PR DESCRIPTION
## Summary
- restyle the shared ❔ help affordance as a CSS hover tooltip so uploader and form helpers no longer leave stale popover outlines
- inject the tooltip CSS once per session while escaping help copy to keep multiline guidance readable and safe
- note the hover tooltip behaviour change in update1015.md for tracking

## Testing
- python -m compileall pages_logic/run_models.py

------
https://chatgpt.com/codex/tasks/task_e_68f0056aa490832b8f3181bceb8c27dd