### PR TITLE
Fix TEXGI smoothness gradients

### DIFF
--- a/models/mysa.py
+++ b/models/mysa.py
@@ -558,8 +558,13 @@ def integrated_gradients_time(
         Xpath.requires_grad_(True)
         hazards = f(Xpath, **kwargs) if kwargs else f(Xpath)  # [B, T]
         out = hazards[:, hazard_index]          # focus on bin t
-        grads = torch.autograd.grad(out.sum(), Xpath, retain_graph=False, create_graph=False)[0]
-        atts += grads
+        grads = torch.autograd.grad(
+            out.sum(),
+            Xpath,
+            retain_graph=False,
+            create_graph=torch.is_grad_enabled(),
+        )[0]
+        atts = atts + grads
     atts = atts * Xdiff / float(len(alphas))
     return atts
 


### PR DESCRIPTION
## Summary
- allow TEXGI time-series integrated gradients to keep computation graphs during training so smoothness regularization backpropagates
- accumulate attribution estimates without in-place ops so gradients are preserved for the smoothness penalty

## Testing
- python -m compileall models/mysa.py

------
https://chatgpt.com/codex/tasks/task_e_68f111bf99bc832b94c9ea7e9fe4939d