### PR TITLE
Align MySA priors UI and support resnet18 preview

### DIFF
--- a/models/multimodal.py
+++ b/models/multimodal.py
@@ -7,7 +7,7 @@ can be swapped out with more sophisticated encoders later on.
 
 The model consists of three encoders:
 
-* :class:`ImageEncoder` – wraps a torchvision backbone (ResNet50 or ViT) and
+* :class:`ImageEncoder` – wraps a torchvision backbone (ResNet18/50 or ViT) and
   outputs a single feature vector per image.
 * :class:`SensorEncoder` – encodes 1D sensor sequences via either a simple CNN
   stack or a Transformer encoder.
@@ -35,7 +35,7 @@ class ImageEncoder(nn.Module):
     Parameters
     ----------
     backbone: str
-        Either ``"resnet50"`` or ``"vit"`` (ViT-B/16).
+        Either ``"resnet18"``, ``"resnet50"`` or ``"vit"`` (ViT-B/16).
     pretrained: bool
         If ``True`` use ImageNet weights.
     """
@@ -43,11 +43,23 @@ class ImageEncoder(nn.Module):
     def __init__(self, backbone: str = "resnet50", pretrained: bool = True):
         super().__init__()
         name = backbone.lower()
-        if name == "resnet50":
-            from torchvision.models import resnet50, ResNet50_Weights
+        if name in {"resnet18", "resnet50"}:
+            from torchvision.models import (
+                resnet18,
+                resnet50,
+                ResNet18_Weights,
+                ResNet50_Weights,
+            )
 
-            weights = ResNet50_Weights.DEFAULT if pretrained else None
-            model = resnet50(weights=weights)
+            if name == "resnet18":
+                weights_cls = ResNet18_Weights
+                backbone_fn = resnet18
+            else:
+                weights_cls = ResNet50_Weights
+                backbone_fn = resnet50
+
+            weights = weights_cls.DEFAULT if pretrained else None
+            model = backbone_fn(weights=weights)
             self.out_dim = model.fc.in_features
             model.fc = nn.Identity()
             self.model = model


### PR DESCRIPTION
## Summary
- redesign the MySA expert guidance editor so it reflects the available constraints and shows consistent help tooltips
- update expert rule parsing to accept the simplified UI schema while keeping backward compatibility
- extend the multimodal image encoder to accept a ResNet-18 backbone, preventing preview failures

## Testing
- python -m compileall pages_logic/run_models.py models/multimodal.py


------
https://chatgpt.com/codex/tasks/task_e_68f117960db8832bb92e3c7c9f967992