### PR TITLE
Refine chat agent quick actions and TEXGISA handling

### DIFF
--- a/pages_logic/chat_with_agent.py
+++ b/pages_logic/chat_with_agent.py
@@ -84,6 +84,14 @@ def _style():
             padding: 0.9rem 1.0rem; 
             background: rgba(255,255,255,0.03);
         }
+        .chip-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.6rem;
+        }
+        .chip-row .stButton {
+            flex: 1 1 200px;
+        }
         .chip-row .stButton>button {
             border-radius: 999px;
             padding: 0.42rem 0.9rem;
@@ -93,6 +101,13 @@ def _style():
         }
         .chip-row .stButton>button:hover { background: rgba(255,255,255,0.08); }
         .stChatMessage { margin-bottom: 0.6rem; }
+        .result-card {
+            border: 1px solid rgba(255,255,255,0.12);
+            border-radius: 14px;
+            padding: 1.2rem 1.4rem;
+            background: rgba(255,255,255,0.02);
+            margin-top: 1.2rem;
+        }
         </style>
         """,
         unsafe_allow_html=True,
@@ -363,7 +378,8 @@ def _run_direct(
         batch_size=int(batch_size),
     )
     if algorithm_name == "TEXGISA":
-        cfg["lambda_expert"] = 0.0 if preview else (0.1 if lambda_expert is None else float(lambda_expert))
+        # Restrict TEXGISA runs to the non-expert configuration.
+        cfg["lambda_expert"] = 0.0
     spinner = st.spinner("Running...") if show_status else None
     if spinner:
         spinner.__enter__()
@@ -394,8 +410,8 @@ def _run_direct(
                 if "importance" in key.lower():
                     details.pop(key, None)
 
-    _render_results(res, df_for_km=df_raw)
     st.session_state["last_results"] = res
+    st.session_state["last_results_df"] = df_raw
     return res
 
 # ------------------------ main page ------------------------
@@ -450,12 +466,12 @@ def show():
     if not st.session_state.chat_greeted:
         if has_data:
             greet = (
-                "Hello! Your dataset is loaded. Use the quick buttons for TEXGISA feature-importance runs or launch CoxTime, DeepSurv, and DeepHit directly. "
+                "Hello! Your dataset is loaded. Use the quick buttons to launch TEXGISA (no expert priors), CoxTime, DeepSurv, or DeepHit instantly. "
                 "You can also type commands like 'run deepsurv time=duration event=event' for a guided workflow."
             )
         else:
             greet = (
-                "Hello! Please upload a CSV on the right first. Once it is loaded you can trigger TEXGISA feature-importance training or run TEXGISA, CoxTime, DeepSurv, and DeepHit using the quick actions or chat commands."
+                "Hello! Please upload a CSV on the right first. Once it is loaded you can run TEXGISA, CoxTime, DeepSurv, or DeepHit using the quick actions or chat commands."
             )
         st.session_state.chat_messages.append(AIMessage(content=greet))
         st.session_state.chat_greeted = True
@@ -476,21 +492,22 @@ def show():
 
             cols_qa = st.columns(4)
             with cols_qa[0]:
-                if st.button("Train TEXGISA (with feature importance)", use_container_width=True, disabled=not has_data):
+                if st.button("Run TEXGISA (no expert)", use_container_width=True, disabled=not has_data):
                     t = tcol or "duration"; e = ecol or "event"
-                    _run_direct("TEXGISA", t, e, epochs=150, preview=False, include_importance=True)
+                    _run_direct("TEXGISA", t, e, epochs=120, include_importance=False)
             with cols_qa[1]:
-                if st.button("Train TEXGISA (without feature importance)", use_container_width=True, disabled=not has_data):
-                    t = tcol or "duration"; e = ecol or "event"
-                    _run_direct("TEXGISA", t, e, epochs=80, preview=True, include_importance=False)
-            with cols_qa[2]:
                 if st.button("Run CoxTime", use_container_width=True, disabled=not has_data):
                     t = tcol or "duration"; e = ecol or "event"
                     _run_direct("CoxTime", t, e, epochs=120)
-            with cols_qa[3]:
+            with cols_qa[2]:
                 if st.button("Run DeepSurv", use_container_width=True, disabled=not has_data):
                     t = tcol or "duration"; e = ecol or "event"
                     _run_direct("DeepSurv", t, e, epochs=120)
+            with cols_qa[3]:
+                if st.button("Run DeepHit", use_container_width=True, disabled=not has_data):
+                    t = tcol or "duration"; e = ecol or "event"
+                    _run_direct("DeepHit", t, e, epochs=120)
+            st.markdown('</div>', unsafe_allow_html=True)
 
         # handle injected quick action
         if "__inject_user" in st.session_state:
@@ -499,7 +516,7 @@ def show():
             st.stop()
 
         # chat input — the agent will call tools if prompted properly
-        user_text = st.chat_input("Type a message. E.g., run TEXGISA time=duration event=event")
+        user_text = st.chat_input("Type a message. E.g., run DeepHit time=duration event=event")
         if user_text:
             text = user_text.strip()
             low = text.lower()
@@ -533,7 +550,7 @@ def show():
                 t = _get_arg(r"time(?:_col)?\s*=\s*([\w\.\-]+)", t_guess)
                 e = _get_arg(r"event(?:_col)?\s*=\s*([\w\.\-]+)", e_guess)
                 ep = _get_arg(r"epochs\s*=\s*(\d+)", 80, int)
-                _run_direct("TEXGISA", t, e, epochs=ep, preview=True)
+                _run_direct("TEXGISA", t, e, epochs=ep, preview=True, include_importance=False)
                 st.stop()
 
             if (
@@ -548,7 +565,7 @@ def show():
                 t = _get_arg(r"time(?:_col)?\s*=\s*([\w\.\-]+)", t_guess)
                 e = _get_arg(r"event(?:_col)?\s*=\s*([\w\.\-]+)", e_guess)
                 ep = _get_arg(r"epochs\s*=\s*(\d+)", 150, int)
-                _run_direct("TEXGISA", t, e, epochs=ep, preview=False)
+                _run_direct("TEXGISA", t, e, epochs=ep, preview=False, include_importance=False)
                 st.stop()
 
             # 其他自由文本 -> 走 LLM（但会被 B 步的上下文“约束”）
@@ -582,19 +599,11 @@ def show():
                 epochs = st.number_input("Epochs", 10, 1000, 150, step=10)
                 lr = st.number_input("Learning rate", 1e-5, 1.0, 0.01, step=0.001, format="%.5f")
                 batch_size = st.number_input("Batch size", 8, 512, 64, step=8)
-                importance_mode = st.radio(
-                    "Feature importance output",
-                    (
-                        "Include TEXGISA feature importance",
-                        "Skip feature importance (faster run)",
-                    ),
-                    index=0,
-                    help="Choose whether to generate TEXGISA feature-importance tables alongside survival curves.",
-                )
+                if algo == "TEXGISA":
+                    st.caption("TEXGISA runs use the non-expert configuration (lambda_expert=0).")
 
                 submitted = st.form_submit_button("Run now")
                 if submitted:
-                    include_importance = importance_mode.startswith("Include")
                     _run_direct(
                         "TEXGISA" if algo.startswith("TEXGISA") else algo,
                         time_col,
@@ -602,9 +611,20 @@ def show():
                         epochs=epochs,
                         lr=lr,
                         batch_size=batch_size,
-                        preview=not include_importance,
-                        include_importance=include_importance,
+                        preview=False,
+                        include_importance=False,
                     )
         else:
             st.info("Upload a CSV to enable direct runs.")
         st.markdown("</div>", unsafe_allow_html=True)
+
+    # ---- full-width results panel ----
+    st.markdown("### 📊 Latest Run Results")
+    st.markdown('<div class="result-card">', unsafe_allow_html=True)
+    last_res = st.session_state.get("last_results")
+    df_for_km = st.session_state.get("last_results_df")
+    if last_res:
+        _render_results(last_res, df_for_km=df_for_km)
+    else:
+        st.info("Run any algorithm to see survival metrics, curves, and tables here.")
+    st.markdown("</div>", unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- collapse the chat quick actions into a single non-expert TEXGISA button, add a DeepHit shortcut, and fix the layout wrapper so the buttons are fully visible
- ensure all direct and chat-triggered TEXGISA runs skip expert priors while updating the greetings and input hint to highlight the available algorithms
- streamline the direct-run form by removing the feature-importance toggle and clarifying the enforced TEXGISA configuration

## Testing
- python -m compileall pages_logic/chat_with_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68f94c0b2470832bb5747e8842a17ea4