### PR TITLE
Handle pycox data dir on read-only envs

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,66 @@
+# Free Streamlit Cloud Deployment Plan
+
+This document explains how to put the Survival Analysis platform online with zero
+infrastructure cost. The stack relies on **Streamlit Community Cloud** (free for
+public repos) and the **Hugging Face Inference API** (free tier) so that anyone
+with the link can open the app without running a local LLM server.
+
+## 1. Prepare the repository
+
+1. Fork or clone this repository to your personal GitHub account.
+2. Ensure the new `requirements.txt` is committed so Streamlit knows which
+   Python dependencies to install. It pins `pandas<2.0` (for `dice-ml==0.10`)
+   and adds `pycox` for the survival models.
+3. In Streamlit's **Advanced settings**, set the runtime to **Python 3.10**
+   (or 3.11). These versions have prebuilt CPU wheels for PyTorch and pycox,
+   so the installer succeeds without compiling.
+4. Push the repo to GitHub. Streamlit Cloud only works with public repos in the
+   free plan.
+
+## 2. Create a free Hugging Face access token
+
+1. Visit <https://huggingface.co/settings/tokens> and create a **read** token.
+2. Copy the token value; we will inject it into Streamlit secrets so the app can
+   call the hosted Llama 3 model through the Inference API.
+3. (Optional) If you want to try a different hosted model, note its repository
+   id (e.g., `mistralai/Mixtral-8x7B-Instruct`). The defaults live in
+   `sa_agent.py` and can be overridden with environment variables later.
+
+## 3. Deploy on Streamlit Community Cloud
+
+1. Go to <https://share.streamlit.io>, sign in with GitHub, and click
+   **New app**.
+2. Select your forked repository, pick the default branch, and set
+   `main.py` as the entry point.
+3. In the **Advanced settings → Secrets** panel, paste the following YAML and
+   replace the token placeholder:
+
+   ```toml
+   HF_API_TOKEN = "hf_your_token_here"
+   # (optional) override defaults for the hosted model
+   HF_LLM_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
+   HF_MAX_NEW_TOKENS = "512"
+   HF_TEMPERATURE = "0.7"
+   HF_TOP_P = "0.9"
+   ```
+
+4. Click **Deploy**. Streamlit will automatically install everything listed in
+   `requirements.txt`, boot the app, and expose a public URL that you can share.
+
+## 4. How it works
+
+- `sa_agent.py` now prefers Hugging Face's free Inference API via the
+  `langchain-huggingface` client. Whenever `HF_API_TOKEN` is set, the agent uses
+  the hosted `meta-llama/Meta-Llama-3-8B-Instruct` chat model, so no local vLLM
+  server or paid OpenAI key is required.
+- If you later add other provider keys (Groq, Google, etc.) the agent still
+  understands them, but the deployment works out-of-the-box with only the free
+  Hugging Face token.
+
+## 5. Sharing the public link
+
+Once Streamlit finishes provisioning, you will receive an URL similar to
+`https://your-handle-survival-analysis.streamlit.app`. Share that link with your
+collaborators; they can immediately interact with the platform, upload data, and
+chat with the agent through the free LLM backend.
+

--- a/models/coxtime.py
+++ b/models/coxtime.py
@@ -2,6 +2,11 @@ import numpy as np
 import pandas as pd
 import torchtuples as tt
 from sklearn.model_selection import train_test_split
+
+from utils.pycox_setup import ensure_pycox_writable
+
+ensure_pycox_writable()
+
 from pycox.evaluation import EvalSurv
 from pycox.models import CoxTime
 from pycox.models.cox_time import MLPVanillaCoxTime

--- a/models/deephit.py
+++ b/models/deephit.py
@@ -2,6 +2,11 @@ import numpy as np
 import pandas as pd
 import torchtuples as tt
 from sklearn.model_selection import train_test_split
+
+from utils.pycox_setup import ensure_pycox_writable
+
+ensure_pycox_writable()
+
 from pycox.evaluation import EvalSurv
 from pycox.models import DeepHitSingle
 

--- a/models/deepsurv.py
+++ b/models/deepsurv.py
@@ -2,6 +2,11 @@ import numpy as np
 import pandas as pd
 import torchtuples as tt
 from sklearn.model_selection import train_test_split
+
+from utils.pycox_setup import ensure_pycox_writable
+
+ensure_pycox_writable()
+
 from pycox.evaluation import EvalSurv
 from pycox.models import CoxPH
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,29 @@
+streamlit==1.36.0
+# pandas must stay <2.0.0 to satisfy dice-ml 0.10
+pandas==1.5.3
+numpy==1.26.4
+
+# Survival modeling stack (keeps pycox available on Streamlit Cloud)
+torch==2.3.1
+scikit-learn==1.4.2
+torchtuples==0.2.2
+pycox==0.2.3
+lifelines==0.27.8
+
+# Plotting / viz
+plotly==5.22.0
+matplotlib==3.8.4
+seaborn==0.13.2
+
+# Counterfactuals / LLM tooling
+dice-ml==0.10
+langchain==0.2.6
+langchain-core==0.2.16
+langchain-openai==0.1.14
+langchain-google-genai==1.0.6
+langgraph==0.0.50
+langchain-huggingface==0.0.3
+huggingface_hub==0.23.1
+
+requests==2.32.2
+pytest==8.2.2

--- a/sa_agent.py
+++ b/sa_agent.py
@@ -22,7 +22,29 @@ from sa_tools import (
 # Function to select the LLM based on available API keys (from DRIVE project)
 def get_llm():
     """Selects an appropriate LLM based on environment variables."""
-    # Prioritize local vLLM endpoint
+    # Prefer the free Hugging Face Inference API so Streamlit Cloud deployments
+    # don't depend on self-hosted vLLM endpoints.
+    hf_token = os.getenv("HF_API_TOKEN") or os.getenv("HUGGINGFACEHUB_API_TOKEN")
+    if hf_token:
+        from langchain_huggingface import ChatHuggingFace, HuggingFaceEndpoint
+
+        repo_id = os.getenv("HF_LLM_ID", "meta-llama/Meta-Llama-3-8B-Instruct")
+        max_new_tokens = int(os.getenv("HF_MAX_NEW_TOKENS", "512"))
+        temperature = float(os.getenv("HF_TEMPERATURE", "0.7"))
+        top_p = float(os.getenv("HF_TOP_P", "0.9"))
+
+        endpoint = HuggingFaceEndpoint(
+            repo_id=repo_id,
+            temperature=temperature,
+            top_p=top_p,
+            max_new_tokens=max_new_tokens,
+            huggingfacehub_api_token=hf_token,
+            timeout=120,
+        )
+        return ChatHuggingFace(llm=endpoint)
+
+    # Continue supporting other hosted providers in case a user explicitly sets
+    # those credentials.
     if os.getenv("VLLM_ENDPOINT"):
         from langchain_openai import ChatOpenAI
         return ChatOpenAI(
@@ -32,7 +54,6 @@ def get_llm():
             temperature=0.7,
             max_tokens=1024
         )
-    # Fallback to other free services if needed
     elif os.getenv("GROQ_API_KEY"):
         from langchain_openai import ChatOpenAI
         return ChatOpenAI(
@@ -46,7 +67,9 @@ def get_llm():
         from langchain_google_genai import ChatGoogleGenerativeAI
         return ChatGoogleGenerativeAI(model="gemini-pro", temperature=0.7, max_output_tokens=1024)
     else:
-        raise ValueError("No LLM API key found. Please set VLLM_ENDPOINT, GROQ_API_KEY, or GOOGLE_API_KEY.")
+        raise ValueError(
+            "No LLM API key found. Please set HF_API_TOKEN or another supported provider's key."
+        )
 
 
 # Define the Agent's state

--- a/utils/pycox_setup.py
+++ b/utils/pycox_setup.py
@@ -1,0 +1,48 @@
+"""Utilities to keep pycox usable on read-only package paths.
+
+Some deployment environments mount the virtual environment as read-only.
+`pycox` tries to create a ``datasets/data`` folder inside its package
+directory during import, which raises ``PermissionError`` in those cases.
+
+We pre-create a writable copy of the package (when necessary) and push that
+copy ahead of the default site-packages directory on ``sys.path`` so pycox can
+initialize without touching the original location.
+"""
+
+from importlib.util import find_spec
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+
+def ensure_pycox_writable() -> None:
+    """Make sure pycox imports even if site-packages is read-only.
+
+    If ``pycox`` resides in a read-only directory, copy it to a writable temp
+    directory and point ``sys.path`` there before the first pycox import.
+    """
+
+    spec = find_spec("pycox")
+    if not spec or not spec.submodule_search_locations:
+        return
+
+    pkg_root = Path(spec.submodule_search_locations[0])
+    data_dir = pkg_root / "datasets" / "data"
+
+    try:
+        data_dir.mkdir(parents=True, exist_ok=True)
+        return
+    except PermissionError:
+        pass
+
+    cache_root = Path(tempfile.gettempdir()) / "pycox_pkg"
+    if not cache_root.exists():
+        shutil.copytree(pkg_root, cache_root, dirs_exist_ok=True)
+
+    cache_data = cache_root / "datasets" / "data"
+    cache_data.mkdir(parents=True, exist_ok=True)
+
+    cache_parent = str(cache_root.parent)
+    if cache_parent not in sys.path:
+        sys.path.insert(0, cache_parent)


### PR DESCRIPTION
## Summary
- add a pycox setup helper that mirrors the package into a writable temp location when site-packages is read-only
- run the pycox setup step before importing survival models to avoid PermissionError on dataset cache creation

## Testing
- pytest utils/test_identifiers.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e00e98c48832b8024747654c7eb30)