### PR TITLE
Ensure pycox copy is importable in read-only environments

### DIFF
--- a/utils/pycox_setup.py
+++ b/utils/pycox_setup.py
@@ -37,12 +37,14 @@ def ensure_pycox_writable() -> None:
         pass
 
     cache_root = Path(tempfile.gettempdir()) / "pycox_pkg"
-    if not cache_root.exists():
-        shutil.copytree(pkg_root, cache_root, dirs_exist_ok=True)
+    cache_pkg = cache_root / "pycox"
 
-    cache_data = cache_root / "datasets" / "data"
+    if not cache_pkg.exists():
+        shutil.copytree(pkg_root, cache_pkg, dirs_exist_ok=True)
+
+    cache_data = cache_pkg / "datasets" / "data"
     cache_data.mkdir(parents=True, exist_ok=True)
 
-    cache_parent = str(cache_root.parent)
+    cache_parent = str(cache_root)
     if cache_parent not in sys.path:
         sys.path.insert(0, cache_parent)


### PR DESCRIPTION
## Summary
- copy pycox into a temp directory named for the package when site-packages is read-only
- add the temporary package location to sys.path so imports resolve to the writable copy

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e8d226b28832b9fc729c1ab6d1e7f)