### PR TITLE
Add risk scoring and counterfactual tooling

### DIFF
--- a/algorithm/CF.py
+++ b/algorithm/CF.py
@@ -1,0 +1,120 @@
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+import torch
+
+
+@dataclass
+class CFResult:
+    table: pd.DataFrame
+    summary: Dict[str, Any]
+    save_path: Optional[str] = None
+
+
+def _select_interval(hazards: np.ndarray, interval: Optional[int]) -> np.ndarray:
+    if interval is None:
+        # pick per-sample peak hazard interval
+        peak_idx = np.argmax(hazards, axis=1)
+        rows = np.arange(len(hazards))
+        return hazards[rows, peak_idx]
+    idx = max(0, min(int(interval) - 1, hazards.shape[1] - 1))
+    return hazards[:, idx]
+
+
+def generate_cf_from_arrays(
+    hazards: Iterable[Iterable[float]] | torch.Tensor,
+    risk_scores: Optional[Iterable[float]] = None,
+    interval: Optional[int] = None,
+    feature_names: Optional[Sequence[str]] = None,
+    save_path: Optional[str] = None,
+) -> CFResult:
+    """Create lightweight post-hoc counterfactual suggestions from hazards.
+
+    The routine consumes pre-computed hazards (shape ``[N, T]``) and optional
+    risk scores. It proposes interval-specific adjustments by reducing the
+    dominant hazard by 20% and emitting clinically-actionable text that can be
+    surfaced in UI/report layers.
+    """
+
+    haz = torch.as_tensor(hazards, dtype=torch.float32).cpu().numpy()
+    if haz.ndim == 1:
+        haz = haz[:, None]
+
+    risks = risk_scores
+    if risks is None:
+        risks = haz.sum(axis=1)
+    risks = np.asarray(risks, dtype=float).flatten()
+
+    target_hazard = _select_interval(haz, interval)
+    baseline_hazard = target_hazard.copy()
+    suggested = np.clip(target_hazard * 0.8, a_min=0.0, a_max=None)
+
+    suggestions = []
+    for i in range(len(risks)):
+        top_features = ""
+        if feature_names:
+            # rotate through features for a lightweight call-to-action
+            feats = ", ".join(feature_names[:3]) if len(feature_names) >= 3 else ", ".join(feature_names)
+            top_features = f" Prioritise stabilising {feats}."
+        target_interval = (int(interval) if interval is not None else int(np.argmax(haz[i]) + 1))
+        suggestions.append(
+            {
+                "sample_id": i,
+                "target_interval": target_interval,
+                "current_hazard": float(baseline_hazard[i]),
+                "suggested_hazard": float(suggested[i]),
+                "risk_score": float(risks[i]),
+                "action": (
+                    f"Focus on interval {target_interval}: reduce hazard from {baseline_hazard[i]:.3f} to "
+                    f"≈{suggested[i]:.3f} via tighter symptom monitoring, follow-up scheduling, and adherence support."
+                    + top_features
+                ),
+            }
+        )
+
+    cf_table = pd.DataFrame(suggestions)
+    summary = {
+        "interval": interval or "peak",
+        "mean_risk": float(np.mean(risks)) if risks.size else 0.0,
+        "mean_target_hazard": float(np.mean(baseline_hazard)) if baseline_hazard.size else 0.0,
+    }
+
+    if save_path:
+        cf_table.to_csv(save_path, index=False)
+    return CFResult(table=cf_table, summary=summary, save_path=save_path)
+
+
+def load_model_for_cf(model_class, state_path: str, **model_kwargs):
+    """Instantiate a model and restore weights for CF simulation."""
+
+    model = model_class(**model_kwargs)
+    state = torch.load(state_path, map_location="cpu")
+    model.load_state_dict(state)
+    model.eval()
+    return model
+
+
+def run_cf_simulation(
+    model: torch.nn.Module,
+    dataloader,
+    interval: Optional[int] = None,
+    save_path: Optional[str] = None,
+    feature_names: Optional[Sequence[str]] = None,
+):
+    """Compute hazards using a restored model and dispatch CF generation."""
+
+    hazards_list = []
+    for batch in dataloader:
+        if isinstance(batch, (list, tuple)) and not hasattr(batch, "_fields"):
+            x, _, _, mod_mask = batch
+        else:
+            x = batch["x"] if isinstance(batch, dict) else getattr(batch, "x")
+            mod_mask = batch.get("mod_mask") if isinstance(batch, dict) else getattr(batch, "mod_mask", None)
+        with torch.no_grad():
+            hz = model(x, mod_mask)
+        hazards_list.append(hz.cpu())
+
+    hazards = torch.cat(hazards_list, dim=0)
+    return generate_cf_from_arrays(hazards, interval=interval, feature_names=feature_names, save_path=save_path)

--- a/algorithm/__init__.py
+++ b/algorithm/__init__.py
@@ -1,0 +1,5 @@
+"""Algorithm utilities (e.g., counterfactuals)."""
+
+from .CF import generate_cf_from_arrays, load_model_for_cf, run_cf_simulation
+
+__all__ = ["generate_cf_from_arrays", "load_model_for_cf", "run_cf_simulation"]

--- a/data.py
+++ b/data.py
@@ -137,3 +137,20 @@ def create_dataloaders(
         num_workers=num_workers, pin_memory=pin_memory, persistent_workers=use_persistent
     )
     return train_loader, val_loader
+
+
+def export_dataset_arrays(loader: DataLoader):
+    """Collect tensors from a data loader for CF/analysis utilities."""
+
+    xs, ys, ms = [], [], []
+    for X, y, m in loader:
+        xs.append(X.cpu())
+        ys.append(y.cpu())
+        ms.append(m.cpu())
+    if not xs:
+        return None
+    return {
+        "x": torch.cat(xs, dim=0),
+        "y": torch.cat(ys, dim=0),
+        "m": torch.cat(ms, dim=0),
+    }

--- a/model.py
+++ b/model.py
@@ -9,6 +9,7 @@ class MultiTaskModel(nn.Module):
     Shared MLP trunk -> per-time-bin hazards via linear head over shared features.
     Returns hazards in shape [B, T].
     """
+
     def __init__(self, input_dim: int, num_bins: int, hidden: int = 256, depth: int = 2, dropout: float = 0.2):
         super().__init__()
         layers = []
@@ -20,7 +21,7 @@ class MultiTaskModel(nn.Module):
             d = hidden
         self.trunk = nn.Sequential(*layers)
         self.hazard_layer = nn.Linear(d, num_bins)
-        self.num_bins = num_bins          
+        self.num_bins = num_bins
         # Xavier init
         for m in self.modules():
             if isinstance(m, nn.Linear):
@@ -28,13 +29,17 @@ class MultiTaskModel(nn.Module):
                 if m.bias is not None:
                     nn.init.zeros_(m.bias)
 
-    def forward(self, x, return_embeddings: bool = False):
+    def forward(self, x, mod_mask=None, return_embeddings: bool = False):
         """Run the shared trunk and hazard head.
 
         Parameters
         ----------
         x: torch.Tensor
             Input features of shape ``[B, D]``.
+        mod_mask: torch.Tensor, optional
+            Unused placeholder to maintain compatibility with callers that pass
+            modality masks; present to provide a unified risk interface for
+            single- and multi-modal models.
         return_embeddings: bool, default False
             When ``True`` also return the hidden representation produced by the
             shared trunk so downstream routines can reuse it for attribution
@@ -47,3 +52,18 @@ class MultiTaskModel(nn.Module):
         if return_embeddings:
             return hazards, h
         return hazards
+
+    @torch.no_grad()
+    def predict_risk(self, x, mod_mask=None, interval: int | None = None):
+        """Return per-sample risk scores.
+
+        By default, risk is the sum of hazards across all intervals; when an
+        ``interval`` is specified (1-indexed) the method returns the hazard for
+        that interval to support interval-specific risk inspection.
+        """
+
+        hazards = self.forward(x, mod_mask)
+        if interval is not None:
+            idx = max(0, min(int(interval) - 1, hazards.shape[1] - 1))
+            return hazards[:, idx]
+        return hazards.sum(dim=1)

--- a/models/multimodal_survival.py
+++ b/models/multimodal_survival.py
@@ -68,3 +68,13 @@ class MultiModalSurvivalModel(nn.Module):
 
         hazards = torch.sigmoid(self.hazard_layer(fused))
         return hazards
+
+    @torch.no_grad()
+    def predict_risk(self, inputs: Dict[str, torch.Tensor], modality_masks: Optional[torch.Tensor] = None, interval: int | None = None) -> torch.Tensor:
+        """Return per-sample risk scores or interval hazards for CF/UX layers."""
+
+        hazards = self.forward(inputs, modality_masks)
+        if interval is not None:
+            idx = max(0, min(int(interval) - 1, hazards.shape[1] - 1))
+            return hazards[:, idx]
+        return hazards.sum(dim=1)


### PR DESCRIPTION
## Summary
- capture risk scores during evaluation, persist them with C-index results, and surface guidance in the UI
- expose model-side risk prediction helpers and save evaluation artifacts for downstream analysis
- add a counterfactual generator module and UI hook to simulate interval-specific suggestions from saved hazards

## Testing
- python -m compileall algorithm trainer.py model.py models/multimodal_survival.py pages_logic/run_models.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929203305a8832b9b9ae07162350779)