### PR TITLE
Add feature-level counterfactual mode

### DIFF
--- a/models/coxtime.py
+++ b/models/coxtime.py
@@ -160,7 +160,7 @@ def run_coxtime(data, config):
     c_index_test = ev_test.concordance_td()
     integrated_brier_score = ev_test.integrated_brier_score(time_grid)
     integrated_nbll = ev_test.integrated_nbll(time_grid)
-    
+
     return {
         "Partial Log Likelihood": partial_ll,
         "C-index (Train)": c_index_train,
@@ -168,6 +168,9 @@ def run_coxtime(data, config):
         "C-index (Test)": c_index_test,
         "Integrated Brier Score": integrated_brier_score,
         "Integrated Negative Log-Likelihood": integrated_nbll,
-        "Surv_Test": surv_test
+        "Surv_Test": surv_test,
+        # Preserve aligned test features for downstream CF exploration.
+        "cf_features": X_test.reset_index(drop=True),
+        "cf_feature_names": list(X.columns),
     }
 

--- a/models/deephit.py
+++ b/models/deephit.py
@@ -138,6 +138,9 @@ def run_deephit(data, config):
         "C-index (Test)": c_index_test,
         "Integrated Brier Score": integrated_brier_score,
         "Integrated Negative Log-Likelihood": integrated_nbll,
-        "Surv_Test": surv_test
+        "Surv_Test": surv_test,
+        # Preserve aligned test features for downstream CF exploration.
+        "cf_features": X_test.reset_index(drop=True),
+        "cf_feature_names": list(X.columns),
     }
 

--- a/models/deepsurv.py
+++ b/models/deepsurv.py
@@ -129,7 +129,7 @@ def run_deepsurv(data, config):
     time_grid = np.linspace(test_durations.min(), test_durations.max(), 100)
     integrated_brier_score = ev_test.integrated_brier_score(time_grid)
     integrated_nbll = ev_test.integrated_nbll(time_grid)
-    
+
     return {
         "Partial Log Likelihood": partial_ll,
         "C-index (Train)": c_index_train,
@@ -137,6 +137,9 @@ def run_deepsurv(data, config):
         "C-index (Test)": c_index_test,
         "Integrated Brier Score": integrated_brier_score,
         "Integrated Negative Log-Likelihood": integrated_nbll,
-        "Surv_Test": surv_test
+        "Surv_Test": surv_test,
+        # Preserve aligned test features for downstream CF exploration.
+        "cf_features": X_test.reset_index(drop=True),
+        "cf_feature_names": list(X.columns),
     }
 


### PR DESCRIPTION
## Summary
- preserve aligned test features across models to enable per-patient counterfactual explanations
- add feature-based counterfactual generator that surfaces actionable suggestions from lower-risk neighbours
- update UI to support single-patient mode with up to five suggestions and retain batch interval search

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929277d90d4832b812f680666bde9b8)