### PR TITLE
Set Hugging Face endpoint to router

### DIFF
--- a/sa_agent.py
+++ b/sa_agent.py
@@ -25,7 +25,11 @@ def get_llm():
     """Selects an appropriate LLM based on environment variables."""
 
     hf_token = None
-    
+
+    # Explicitly set the new Hugging Face router endpoint to avoid the deprecated
+    # api-inference.huggingface.co URL (returns HTTP 410).
+    os.environ.setdefault("HF_ENDPOINT", "https://router.huggingface.co")
+
     possible_keys = ["HF_TOKEN", "HUGGINGFACEHUB_API_TOKEN", "HF_API_TOKEN"]
     
     for key in possible_keys:


### PR DESCRIPTION
## Summary
- set HF_ENDPOINT to the new router endpoint to avoid deprecated api-inference URL
- document change inline in LLM initialization

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69371b02b8f4832b9c8aaf3cb4987cf4)