### PR TITLE
Fix Hugging Face endpoint validation

### DIFF
--- a/sa_agent.py
+++ b/sa_agent.py
@@ -25,7 +25,12 @@ def get_llm():
     """Selects an appropriate LLM based on environment variables."""
 
     hf_token = None
-    
+
+    # Explicitly set the new Hugging Face router endpoint to avoid the deprecated
+    # api-inference.huggingface.co URL (returns HTTP 410).
+    default_endpoint = "https://router.huggingface.co"
+    os.environ.setdefault("HF_ENDPOINT", default_endpoint)
+
     possible_keys = ["HF_TOKEN", "HUGGINGFACEHUB_API_TOKEN", "HF_API_TOKEN"]
     
     for key in possible_keys:
@@ -39,21 +44,30 @@ def get_llm():
                 hf_token = os.getenv(key)
                 break
 
+    if hf_token:
+        hf_token = str(hf_token).strip()
     if not hf_token:
         st.error("⚠️ not found Hugging Face Token")
         raise ValueError("Hugging Face Token not found.")
 
-    repo_id = os.getenv("HF_LLM_ID", "meta-llama/Meta-Llama-3-8B-Instruct")
+    repo_id = os.getenv("HF_LLM_ID", "meta-llama/Meta-Llama-3-8B-Instruct") or "meta-llama/Meta-Llama-3-8B-Instruct"
+    repo_id = repo_id.strip()
     max_new_tokens = int(os.getenv("HF_MAX_NEW_TOKENS", "512"))
     temperature = float(os.getenv("HF_TEMPERATURE", "0.7"))
     top_p = float(os.getenv("HF_TOP_P", "0.9"))
 
+    # Fall back to the router endpoint if the env var is missing or blank to avoid
+    # Pydantic validation failures from an empty URL.
+    endpoint_url = os.getenv("HF_ENDPOINT") or default_endpoint
+
     endpoint = HuggingFaceEndpoint(
+        model=repo_id,
         repo_id=repo_id,
+        endpoint_url=endpoint_url,
         temperature=temperature,
         top_p=top_p,
         max_new_tokens=max_new_tokens,
-        huggingfacehub_api_token=hf_token, # 显式传入 Token
+        huggingfacehub_api_token=hf_token,  # 显式传入 Token
         timeout=120,
     )
     


### PR DESCRIPTION
## Summary
- ensure Hugging Face token and model defaults are stripped and non-empty before initializing the client
- fall back to the router endpoint when the HF_ENDPOINT variable is missing or blank to avoid validation errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69371b02b8f4832b9c8aaf3cb4987cf4)