### PR TITLE
Fix page exports and offline tool binding

### DIFF
--- a/pages_logic/__init__.py
+++ b/pages_logic/__init__.py
@@ -1,0 +1,11 @@
+# Re-export page modules so `from pages_logic import ...` works
+from . import home, algorithms, run_models, publications, contact, chat_with_agent
+
+__all__ = [
+    "home",
+    "algorithms",
+    "run_models",
+    "publications",
+    "contact",
+    "chat_with_agent",
+]


### PR DESCRIPTION
## Summary
- expose chat page module via pages_logic package to satisfy imports
- let offline fallback chat model support tool binding calls to avoid runtime errors

## Testing
- python -m py_compile sa_agent.py pages_logic/__init__.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693721d863a0832b98cc6396711dc806)