### PR TITLE
Ensure set_page_config runs before other Streamlit calls

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,11 +5,13 @@ ROOT = os.path.dirname(os.path.abspath(__file__))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 import streamlit as st
-from pages_logic import home, algorithms, run_models, publications, contact, chat_with_agent 
+from pages_logic import home, algorithms, run_models, publications, contact, chat_with_agent
 from utils import user_center
 import pandas as pd
-import streamlit as st
 from sa_data_manager import DataManager # 确保导入了DataManager类
+
+# Streamlit 要求 set_page_config 是脚本中的第一条命令，因此放在任何其他 st 调用之前
+st.set_page_config(page_title="DHAI Lab Survival Analysis Platform", layout="wide")
 
 if 'data_manager' not in st.session_state:
     st.session_state.data_manager = DataManager()
@@ -17,8 +19,6 @@ def set_page(page):
     st.session_state["current_page"] = page
 
 def main():
-    st.set_page_config(page_title="DHAI Lab Survival Analysis Platform", layout="wide")
-    
     # 自定义 CSS 样式，让导航按钮更美观
     st.markdown("""
     <style>

--- a/pages_logic/__init__.py
+++ b/pages_logic/__init__.py
@@ -1,0 +1,11 @@
+# Re-export page modules so `from pages_logic import ...` works
+from . import home, algorithms, run_models, publications, contact, chat_with_agent
+
+__all__ = [
+    "home",
+    "algorithms",
+    "run_models",
+    "publications",
+    "contact",
+    "chat_with_agent",
+]


### PR DESCRIPTION
## Summary
- move `st.set_page_config` to the top of the script as the first Streamlit command
- remove duplicate Streamlit import and keep single configuration call

## Testing
- python -m py_compile main.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693721d863a0832b98cc6396711dc806)