### PR TITLE
Ensure Hugging Face token is available to endpoint

### DIFF
--- a/sa_agent.py
+++ b/sa_agent.py
@@ -101,6 +101,10 @@ def get_llm():
         st.error("⚠️ Hugging Face Token not found. Falling back to offline mode.")
         return OfflineFallbackChatModel(reason)
 
+    # Standardize the token location so downstream LangChain helpers can pick it up.
+    # HuggingFaceEndpoint checks the HUGGINGFACEHUB_API_TOKEN env var by default.
+    os.environ["HUGGINGFACEHUB_API_TOKEN"] = hf_token
+
     try:
         endpoint = HuggingFaceEndpoint(
             repo_id=repo_id,


### PR DESCRIPTION
## Summary
- standardize the Hugging Face token by writing it to HUGGINGFACEHUB_API_TOKEN before creating the endpoint
- keep explicit token usage so LangChain components can authenticate reliably

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69372802ac40832b88ab000973d64512)