### PR TITLE
Fix Streamlit page config ordering

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,13 +5,14 @@ ROOT = os.path.dirname(os.path.abspath(__file__))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 import streamlit as st
+
+# Streamlit 要求 set_page_config 是脚本中的第一条命令，因此放在任何其他 st 调用之前
+st.set_page_config(page_title="DHAI Lab Survival Analysis Platform", layout="wide")
+
 from pages_logic import home, algorithms, run_models, publications, contact, chat_with_agent
 from utils import user_center
 import pandas as pd
 from sa_data_manager import DataManager # 确保导入了DataManager类
-
-# Streamlit 要求 set_page_config 是脚本中的第一条命令，因此放在任何其他 st 调用之前
-st.set_page_config(page_title="DHAI Lab Survival Analysis Platform", layout="wide")
 
 if 'data_manager' not in st.session_state:
     st.session_state.data_manager = DataManager()


### PR DESCRIPTION
## Summary
- move `st.set_page_config` to the top of the Streamlit script so it runs before any other Streamlit calls
- keep downstream imports unchanged while ensuring configuration happens first to avoid runtime errors

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69372802ac40832b88ab000973d64512)