### PR TITLE
Validate Hugging Face token and model access before initializing endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,13 +5,14 @@ ROOT = os.path.dirname(os.path.abspath(__file__))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 import streamlit as st
+
+# Streamlit 要求 set_page_config 是脚本中的第一条命令，因此放在任何其他 st 调用之前
+st.set_page_config(page_title="DHAI Lab Survival Analysis Platform", layout="wide")
+
 from pages_logic import home, algorithms, run_models, publications, contact, chat_with_agent
 from utils import user_center
 import pandas as pd
 from sa_data_manager import DataManager # 确保导入了DataManager类
-
-# Streamlit 要求 set_page_config 是脚本中的第一条命令，因此放在任何其他 st 调用之前
-st.set_page_config(page_title="DHAI Lab Survival Analysis Platform", layout="wide")
 
 if 'data_manager' not in st.session_state:
     st.session_state.data_manager = DataManager()

--- a/sa_agent.py
+++ b/sa_agent.py
@@ -1,6 +1,7 @@
 # sa_agent.py
 import streamlit as st
 from langchain_huggingface import ChatHuggingFace, HuggingFaceEndpoint
+from huggingface_hub import HfApi, HfHubHTTPError
 from typing import TypedDict, Annotated, List, Dict, Any
 import operator
 import os
@@ -91,6 +92,11 @@ def get_llm():
                 hf_token = os.getenv(key)
                 break
 
+    # Normalise whitespace to avoid accidental trailing newlines from secrets files
+    # that would make the token invalid during authentication.
+    if hf_token:
+        hf_token = hf_token.strip()
+
     repo_id = os.getenv("HF_LLM_ID", "meta-llama/Meta-Llama-3-8B-Instruct")
     max_new_tokens = int(os.getenv("HF_MAX_NEW_TOKENS", "512"))
     temperature = float(os.getenv("HF_TEMPERATURE", "0.7"))
@@ -101,9 +107,48 @@ def get_llm():
         st.error("⚠️ Hugging Face Token not found. Falling back to offline mode.")
         return OfflineFallbackChatModel(reason)
 
+    # Validate the token early so we can surface clearer guidance (e.g., license
+    # acceptance or typos) before attempting to construct the endpoint.
+    api = HfApi(token=hf_token)
+    try:
+        api.whoami()
+    except Exception as exc:
+        reason = f"Hugging Face token was rejected: {exc}"
+        st.error(
+            "⚠️ Hugging Face token could not be authenticated. "
+            "Double-check the value (no trailing spaces/newlines) or generate a new token."
+        )
+        return OfflineFallbackChatModel(reason)
+
+    # Check model access up front to catch missing license acceptance, which also
+    # presents as a 401/403 during endpoint initialization.
+    try:
+        api.model_info(repo_id)
+    except HfHubHTTPError as exc:
+        status = getattr(exc.response, "status_code", None)
+        if status in {401, 403}:
+            reason = (
+                f"Token lacks access to {repo_id}. Please accept the model license "
+                "or set HF_LLM_ID to a model your token can use."
+            )
+            st.error(
+                "⚠️ Token is valid but does not have permission for the configured model. "
+                "Accept the model license on Hugging Face or choose a public model via HF_LLM_ID."
+            )
+            return OfflineFallbackChatModel(reason)
+        # For other HTTP errors (e.g., model missing), provide a helpful message.
+        reason = f"Unable to fetch model metadata for {repo_id}: {exc}"
+        st.error(reason)
+        return OfflineFallbackChatModel(reason)
+
+    # Standardize the token location so downstream LangChain helpers can pick it up.
+    # HuggingFaceEndpoint checks the HUGGINGFACEHUB_API_TOKEN env var by default.
+    os.environ["HUGGINGFACEHUB_API_TOKEN"] = hf_token
+
     try:
         endpoint = HuggingFaceEndpoint(
             repo_id=repo_id,
+            task="text-generation",
             temperature=temperature,
             top_p=top_p,
             max_new_tokens=max_new_tokens,


### PR DESCRIPTION
## Summary
- verify Hugging Face tokens with whoami before constructing the endpoint
- check configured model access and surface guidance when license acceptance or permissions are missing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69372802ac40832b88ab000973d64512)