### PR TITLE
Refine compiled UI onboarding guides for first-time users

### DIFF
--- a/docs/Compiled_UI_Onboarding_Guide.md
+++ b/docs/Compiled_UI_Onboarding_Guide.md
@@ -1,0 +1,223 @@
+# DHAI Survival Analysis Platform (Compiled UI) Onboarding Guide
+- Version: written against the compiled UI; last updated: 2025-05-07 (matches current release)
+- Target users: first-time clinicians/researchers/students using survival analysis or this platform
+- You will learn:
+  - Run a 30-second loop: upload → map columns → train → read metrics/curves → export
+  - Match archetypes and scenarios to the right pages/modules
+  - Locate navigation, sidebar, upload, and algorithm controls quickly
+  - Follow page-by-page steps with checkpoints to verify results
+  - Troubleshoot common errors on data, parameters, and environment
+
+> Shortcut reading: want one successful run? Read **0. Quick Start** + **4.3 Model Training** + first two FAQ items. Want concepts? Read **2. Interface Overview** + **4.2 Algorithm Tutor**. Need screenshots? Jump to **3. Screenshot Checklist**.
+
+> What this platform does NOT do: it does not replace clinical decisions; outputs are for research/demo and need professional judgment.
+
+## 0. Quick Start (30s)
+1. Upload CSV (default via **Model Training**): choose file in the upload area.
+   - Checkpoint: `Loaded <filename> · shape = rows × cols` or column preview appears.
+2. Map columns: in **Model Training** mapping table select `duration` (time) and `event` (0/1).
+   - Checkpoint: dropdowns show the selected time and event columns.
+3. Pick algorithm and run: choose **TEXGISA / CoxTime / DeepSurv / DeepHit** → click Run.
+   - Checkpoint: progress/success message; no errors.
+4. Read results: in result cards, view C-index, predicted survival curves, KM curve; expand Feature Importance when present.
+   - Checkpoint: C-index appears; charts render without blank areas.
+5. Export/replicate: download tables/feature importance, or note time/event columns, algorithm, and epochs.
+   - Checkpoint: file saves or parameters are captured.
+
+Optional path: if you prefer chat-driven steps, use **Chat with Agent** (Upload CSV + Direct Run); follow the same flow as above.
+
+## 1. User Archetypes & Typical Scenarios
+### 1.1 Archetypes
+- Role: Clinical PI / Physician
+  - Goal: verify model separates risk groups and highlights key risk factors.
+  - Pain points: unfamiliar with survival params; needs interpretable outputs.
+  - Pages used most: Model Training, Chat with Agent, Algorithm Tutor
+  - Outputs cared most: C-index, KM curves, Feature Importance (direction + weight)
+- Role: Data Analyst / Student
+  - Goal: run pipeline, tune hyperparameters, compare algorithms.
+  - Pain points: wrong time/event mapping; unclear parameter meanings.
+  - Pages used most: Model Training, Algorithm Tutor
+  - Outputs cared most: training logs, metric tables, curves, exported configs
+- Role: Demo Specialist / Implementation Consultant
+  - Goal: present an end-to-end demo and interpretation.
+  - Pain points: stable steps, clean screenshots, avoid errors.
+  - Pages used most: Home, Model Training, Chat with Agent, Publications
+  - Outputs cared most: page titles + step lists, result cards, export links
+- Role: Instructor / TA
+  - Goal: explain concepts and algorithm differences; guide student practice.
+  - Pain points: students unfamiliar with metrics/curves; need visuals.
+  - Pages used most: Algorithm Tutor, Home, Model Training
+  - Outputs cared most: hazard/survival animations, algorithm tables, KM curves
+
+### 1.2 Scenarios
+- Scenario: Clinical PI checks model usability
+  - Goal: see risk separation and variable explanations
+  - Page: Model Training → Results
+  - Action: upload data, map duration/event, select TEXGISA, enable Feature Importance (if present), click Run
+  - Output: C-index, predicted survival curves, KM, Top-k Feature Importance
+  - Next: download feature importance for discussion
+- Scenario: Analyst compares algorithms
+  - Goal: compare CoxTime / DeepSurv / DeepHit / TEXGISA metrics
+  - Page: Chat with Agent (quick buttons) or Model Training (form)
+  - Action: run four algorithms on same dataset, record C-index
+  - Output: multiple result cards with metrics
+  - Next: pick best algorithm, adjust epochs/lr, rerun
+- Scenario: Demo specialist needs screenshots
+  - Goal: collect high-quality captures
+  - Page: Home, Algorithm Tutor, Model Training, Chat with Agent, Publications, Contact
+  - Action: expand Quick Start, move hazard ratio sliders, run one model and show results
+  - Output: titles + descriptions, animation charts, metric cards
+  - Next: capture per checklist and build slides
+- Scenario: TA teaches concepts
+  - Goal: animate hazard/survival, explain KM
+  - Page: Algorithm Tutor
+  - Action: adjust Median Survival & Hazard Ratio sliders, play animation
+  - Output: Hazard & Survival charts, trend explanations
+  - Next: ask students to upload sample data in Model Training for practice
+
+## 2. Interface Overview (Compiled)
+- Top navigation (button text): 🏠 Home | 📘 Algorithm Tutor | 🧪 Model Training (Run Models) | 🤖 Chat with Agent | 📄 Publications | ✉️ Contact
+- Sidebar:
+  - User Center dropdown: Home / Our Datasets / Our Experiments / Our Results / History / Favorite Models (pages beyond Home show a user-center placeholder)
+  - Settings: Theme Switch, Multi-language Support (Under Development)
+  - Help Bot: type questions to get guidance
+- Global concepts:
+  - duration: follow-up/survival time column (numeric)
+  - event: event indicator (1=event, 0=censored)
+  - censoring: observation ended without event; not the same as event
+  - C-index: concordance metric; closer to 1 is better
+  - KM (Kaplan–Meier): stepwise empirical survival curve; long flat segments often mean censoring or no events
+  - hazard/survival: instant risk vs. survival probability; higher hazard → faster survival drop
+
+## 3. Screenshot Checklist (what to capture)
+| Fig | Page | Region to capture (precise module/card/control) | Purpose | Notes |
+|-----|------|-----------------------------------------------|---------|-------|
+| Fig1 | Home | Page title + caption + expanded "🚀 How to Use This System" 5-step list | Show quick-start entry | Expand the accordion |
+| Fig2 | Algorithm Tutor | "📚 Core Survival Analysis Concepts" + hazard/survival animation (play button + sliders) | Explain concepts and interactive controls | Animation controls visible |
+| Fig3 | Algorithm Tutor | "🔍 Choose an Algorithm to Explore" with TEXGISA tab selected | Show algorithm selection and info entry | TEXGISA tab expanded |
+| Fig4 | Model Training | Upload/mapping area: upload control + duration/event dropdown + features list | Demonstrate data prep | Include mapping table if present |
+| Fig5 | Model Training | Training params: Algorithm dropdown + epochs/lr/batch_size inputs + Run button | Show run entry | Pre-run state is fine |
+| Fig6 | Model Training | Results: C-index/metric cards + predicted survival curve (or KM) | Show output reading | Ensure charts rendered |
+| Fig7 | Chat with Agent | Left chat history + "⚡ Quick Actions" row + right "Upload CSV" card | Show chat and quick runs | Better with loaded data |
+| Fig8 | Chat with Agent | Right "🧪 Direct Run" form (algorithm dropdown, time/event selectors, Run now) | Show non-LLM run path | Column dropdowns visible |
+| Fig9 | Publications | Publications table (Title + Paper Link) | Show resource entry | Full table |
+| Fig10 | Contact | Contact card (address/phone/email) | Show contact info | Keep title + caption |
+
+## 4. Page-by-Page Walkthrough
+### 4.1 Home
+- Purpose: read platform intro and quick-start steps.
+- Prepare: none; just know your time/event column names.
+- Steps:
+  1. Expand "🚀 How to Use This System" accordion → read the 5-step loop.
+     - Checkpoint: see upload → map → choose algorithm → interpret → metrics list.
+  2. For concept recap, scroll to "What is Survival Analysis?" and research direction accordions.
+     - Checkpoint: accordions expand and text is readable.
+- Output reading: no metrics here; this page is just entry and context.
+- Export/replicate: capture accordion content for training materials.
+
+### 4.2 Algorithm Tutor
+- Purpose: learn survival concepts, view TEXGISA details and algorithm comparisons, and generate interactive curves.
+- Prepare: none; browsing only.
+- Steps:
+  1. Expand "📚 Core Survival Analysis Concepts" → adjust "Median Survival" and "Hazard Ratio" sliders.
+     - Checkpoint: Hazard vs. Time and Survival vs. Time charts change together; play/pause works.
+     - Common issue: slider beyond range (6–60 months, 0.5–2.0) may stop responding → refresh page.
+  2. Open "🔍 Choose an Algorithm to Explore" and select an algorithm (CoxTime/DeepSurv/DeepHit/TEXGISA).
+     - Checkpoint: matching descriptions and charts appear; if not, ensure selection is not "Select Algorithm".
+  3. Expand "🧭 Algorithm Comparison Guide" to review badge/tag differences.
+- Output reading:
+  - Animation: follow the legend for colors/direction; if no legend, focus on trend (higher hazard → faster survival drop).
+  - Algorithm sections: read formulas/charts to understand model traits.
+- Export/replicate: capture animations and algorithm descriptions per checklist; no file export needed.
+
+### 4.3 Model Training (Run Models)
+- Purpose: upload data, map columns, choose algorithm, train, and view metrics/curves.
+- Prepare:
+  - CSV with at least header example: `duration,event,feature1,feature2`
+  - Event allowed values: 0/1 (convert True/False or Yes/No to 1/0 before upload).
+  - duration must be numeric; non-numeric features are ignored or need prior encoding; fill missing values first.
+- Steps (example: TEXGISA):
+  1. Click "Upload CSV" to choose file.
+     - Checkpoint: shows row/column counts and column names; otherwise an error appears.
+     - Common issue: encoding/delimiter errors → ensure UTF-8 and comma-separated.
+  2. In mapping area, set Time column = duration; Event column = event (or manual choice).
+     - Checkpoint: dropdowns show selected columns; event mapped to 0/1.
+     - Common issue: event column not binary → preprocess to 0/1 before upload.
+  3. Choose Algorithm (TEXGISA/CoxTime/DeepSurv/DeepHit); set Epochs, Learning rate, Batch size.
+     - Checkpoint: numeric boxes accept input; out-of-range values constrained.
+     - Common issue: too-high LR diverges → start with 0.001–0.01.
+  4. Click Run; wait for completion.
+     - Checkpoint: no errors; results show metrics and charts.
+  5. Expand Feature Importance (if supported) to see top-k directions and weights.
+- Output reading:
+  - C-index: >0.6 suggests separability; near 0.5 → check data/features.
+  - Predicted survival curves: larger separation → stronger risk heterogeneity.
+  - KM curves: stepwise drops; long flat tail often means heavy censoring.
+  - Feature Importance: follow the legend for colors/directions; if no legend, read only the ranking, not direction.
+- Export/replicate: use download buttons in results for tables/feature importance; log chosen time/event columns, algorithm, and params.
+
+### 4.4 Chat with Agent
+- Purpose: ask guidance via chat, run algorithms directly, view structured outputs.
+- Prepare: CSV and knowledge of time/event column names.
+- Steps:
+  1. Upload data in the right "Upload CSV" card.
+     - Checkpoint: success message with filename and shape; expand Show columns if available.
+     - Common issue: load fails → verify CSV format and no empty headers.
+  2. Use left "⚡ Quick Actions" if columns auto-detected; click Run TEXGISA / CoxTime / DeepSurv / DeepHit.
+     - Checkpoint: chat shows result summary; if disabled, data not loaded yet.
+  3. Use right "🧪 Direct Run" form: pick Algorithm, Time column, Event column, Epochs/LR/Batch size → Run now.
+     - Checkpoint: result card shows C-index, survival curve, KM; if empty, recheck column mapping.
+  4. For natural-language commands, type “run deepsurv time=duration event=event” in chat.
+     - Checkpoint: agent replies with run status or asks for missing columns.
+- Output reading: same as Model Training; chat replies summarize metrics and chart locations.
+- Export/replicate: download via result cards; copy chat history if needed.
+
+### 4.5 Publications
+- Purpose: view paper links.
+- Steps: no upload; read table and click Paper Link.
+- Output reading: Link column is clickable.
+- Export/replicate: copy links or capture table.
+
+### 4.6 Contact
+- Purpose: access contact info.
+- Steps: read address/phone/email directly.
+- Output reading: use for calls or emails.
+- Export/replicate: screenshot or copy details.
+
+## 5. FAQ & Troubleshooting
+- Symptom: columns not detected after upload
+  - Cause: delimiter/encoding issues or missing header
+  - Fix: ensure UTF-8, comma-separated, first row has column names; re-upload
+- Symptom: wrong duration/event mapping
+  - Cause: unclear naming or mixed characters
+  - Fix: manually pick correct columns; ensure event is 0/1 only
+- Symptom: metrics empty or errors
+  - Cause: missing values, non-numeric features, or invalid params
+  - Fix: clean NA, keep numeric columns; reset LR/batch to defaults; retry
+- Symptom: KM curve looks odd (heavy censoring)
+  - Cause: very low event rate or short follow-up
+  - Fix: check event rate; extend follow-up or filter anomalies; confirm C-index usability
+- Symptom: Feature Importance lacks color/direction
+  - Cause: run without directional info or algorithm unsupported
+  - Fix: choose TEXGISA and enable directional explanations if present; otherwise mark TODO
+- Symptom: LLM/Agent unavailable
+  - Cause: offline or missing token
+  - Fix: use right "🧪 Direct Run" or Model Training page to run directly
+- Symptom: Runs are slow
+  - Cause: too many epochs, tiny batch_size, heavy explanations
+  - Fix: start with epochs 80–120, batch_size ≥32, turn off heavy explanation; check hardware
+- Symptom: Feature directions conflict with domain knowledge
+  - Cause: no standardization or data quality issues
+  - Fix: review preprocessing; if supported, increase smoothing/prior weight; otherwise note for further analysis
+
+## 6. Glossary
+- Survival Time / Survival Time / time until event / Algorithm Tutor animations, column mapping
+- Event Indicator / Event / 1=event, 0=censored / mapping dropdowns, Direct Run form
+- Censoring / Censoring / samples without observed event / KM interpretation, algorithm input
+- Concordance Index / C-index / ranking agreement metric; higher is better / result cards, chat summary
+- Kaplan–Meier Curve / KM / empirical survival curve with steps / results charts
+- Hazard / Hazard / instantaneous risk; higher means faster events / Algorithm Tutor, algorithm descriptions
+- Survival Probability / Survival / 1 - cumulative risk / Algorithm Tutor, results curves
+- Feature Importance / Feature Importance / variable contribution to risk / TEXGISA results
+- Epochs / Epochs / full passes over training data / Model Training, Direct Run form
+- Learning Rate / LR / step size for updates / Model Training, Direct Run form

--- a/docs/编译版页面使用指南.md
+++ b/docs/编译版页面使用指南.md
@@ -1,0 +1,223 @@
+# DHAI 生存分析平台（编译版界面）中文上手指南
+- 版本信息：基于编译版界面撰写，最后更新：2025-05-07（与当前发布一致）
+- 适用人群：首次接触生存分析或本平台的临床/科研/教学用户
+- 你将学会什么：
+  - 30 秒跑通一次上传→映射→训练→查看→导出的闭环
+  - 识别各类用户在不同场景下应使用的页面与模块
+  - 快速定位导航、侧边栏、数据上传与算法选择控件
+  - 在各页面按图索骥完成操作并判断结果是否正常
+  - 遇到常见错误时自查数据、参数与环境
+
+> 只想跑通一次：看 **0. 快速开始** + **4.3 Model Training** + FAQ 前两条。想理解概念：看 **2. 界面总览** + **4.2 Algorithm Tutor**。想做演示截图：直接看 **3. 截图清单**。
+
+> 本平台不做什么：不替代临床决策；结果用于研究/演示，请结合专业判断。
+
+## 0. 快速开始（30 秒）
+1. 上传 CSV（默认用 **Model Training**）：在页面上传区选择文件。
+   - 检查点：看到 `Loaded <文件名> · shape = 行 × 列` 或列名预览。
+2. 映射列：在 **Model Training** 映射表选择 `duration`（时间）与 `event`（0/1）。
+   - 检查点：下拉框显示已选择的时间列和事件列。
+3. 选算法并运行：在表单选择 **TEXGISA / CoxTime / DeepSurv / DeepHit** → 点击 Run。
+   - 检查点：出现进度/成功提示，无报错。
+4. 看结果：在结果卡片查看 C-index、预测存活曲线、KM 曲线，必要时展开 Feature Importance。
+   - 检查点：C-index 出现，曲线渲染无空白。
+5. 导出/复现：在结果区下载表格/特征重要性，或记录时间列、事件列、算法与训练轮数。
+   - 检查点：下载成功或参数被记下。
+
+可选路径：若想边聊边跑，用 **Chat with Agent** 的 Upload CSV + Direct Run；流程与上面一致。
+
+## 1. 用户画像与典型使用场景
+### 1.1 用户画像（archetypes）
+- 角色名称：临床 PI / 医生
+  - 目标：快速验证模型能否区分高低风险人群，查看关键危险因素。
+  - 痛点：不熟悉生存分析参数；需要能读懂的解释。
+  - 他们最常用的页面：Model Training、Chat with Agent、Algorithm Tutor
+  - 他们最关心的输出：C-index、KM 曲线、Feature Importance（方向 + 重要度）
+- 角色名称：数据分析师 / 学生
+  - 目标：跑通管线、调参、对比算法。
+  - 痛点：时间/事件列映射错误、参数含义不清。
+  - 他们最常用的页面：Model Training、Algorithm Tutor
+  - 他们最关心的输出：训练日志、指标表、曲线、导出配置
+- 角色名称：产品演示者 / 实施顾问
+  - 目标：演示完整闭环、展示解释能力。
+  - 痛点：操作步骤要稳、截图要好看、避免报错。
+  - 他们最常用的页面：Home、Model Training、Chat with Agent、Publications
+  - 他们最关心的输出：页面标题+步骤列表、运行结果卡片、导出链接
+- 角色名称：教学/助教
+  - 目标：讲解概念与算法差异、给学生演练。
+  - 痛点：学生不熟悉指标/曲线；需要可视化素材。
+  - 他们最常用的页面：Algorithm Tutor、Home、Model Training
+  - 他们最关心的输出：Hazard/Survival 动画、算法表格、KM 曲线
+
+### 1.2 典型场景（scenarios）
+- 场景：临床 PI 想验证模型可用性
+  - 目标：看模型能否区分风险并解释变量
+  - 打开哪个页面：Model Training → 结果卡片
+  - 做什么：上传数据，映射 duration/event，选 TEXGISA，勾 Feature Importance（若有），点击 Run
+  - 看到什么输出：C-index、预测存活曲线、KM 曲线、Top-k Feature Importance
+  - 下一步：下载特征重要度，带到讨论会
+- 场景：数据分析师要对比算法
+  - 目标：比较 CoxTime / DeepSurv / DeepHit / TEXGISA 的指标
+  - 打开哪个页面：Chat with Agent（快捷按钮）或 Model Training（表单）
+  - 做什么：同一数据集依次运行 4 个算法，记录 C-index
+  - 看到什么输出：多次运行的指标卡片
+  - 下一步：选择最优算法、调整 epochs / lr 再次运行
+- 场景：产品演示者要做截图版 Demo
+  - 目标：快速收集高质量截图
+  - 打开哪个页面：Home、Algorithm Tutor、Model Training、Chat with Agent、Publications、Contact
+  - 做什么：展开 Quick Start、滑动 Hazard Ratio 动画、运行一次模型并展示结果
+  - 看到什么输出：标题+说明、动画图、指标卡片
+  - 下一步：按截图清单导出图片，整理成 PPT
+- 场景：教学助教要讲解概念
+  - 目标：用动画展示 Hazard/Survival，解释 KM 曲线
+  - 打开哪个页面：Algorithm Tutor
+  - 做什么：调整 Median Survival 与 Hazard Ratio 滑块，播放动画
+  - 看到什么输出：Hazard & Survival 双图、动态趋势说明
+  - 下一步：让学生在 Model Training 上传示例数据练习
+
+## 2. 界面总览（编译后）
+- 顶部导航（按按钮文本）：🏠 Home｜📘 Algorithm Tutor｜🧪 Model Training（对应 Run Models）｜🤖 Chat with Agent｜📄 Publications｜✉️ Contact
+- 侧边栏：
+  - User Center 下拉：Home / Our Datasets / Our Experiments / Our Results / History / Favorite Models（点击 Home 以外会显示用户中心占位）
+  - Settings：Theme Switch、Multi-language Support（均为 Under Development）
+  - Help Bot：输入问题可得到操作指引
+- 全局概念：
+  - duration：随访/生存时间列（数值）
+  - event：事件指示（1=事件，0=删失）
+  - censoring：被删失的观察，不等于事件发生
+  - C-index：一致性指标，越接近 1 越好
+  - KM（Kaplan–Meier）：阶梯状经验存活曲线，平段多代表删失或无事件
+  - hazard/survival：瞬时风险/存活概率，hazard 高→survival 下降快
+
+## 3. 截图清单（只告诉我截哪里）
+| 图号 | 页面 | 截图区域（精确到模块/卡片/控件） | 目的 | 备注 |
+|-----|------|----------------------------------|------|------|
+| 图1 | Home | 页面标题 + caption + 「🚀 How to Use This System」展开后的 5 步列表 | 展示快速上手入口 | 折叠块需展开 |
+| 图2 | Algorithm Tutor | 「📚 Core Survival Analysis Concepts」+ Hazard/Survival 动画图（含播放按钮、滑块） | 说明概念与互动控件 | 动画控件可见 |
+| 图3 | Algorithm Tutor | 「🔍 Choose an Algorithm to Explore」下拉选 TEXGISA 后的标签页标题区 | 展示算法选择与说明入口 | 需展开 TEXGISA 页签 |
+| 图4 | Model Training | 数据上传/映射区域：上传控件 + duration/event 下拉 + features 列表 | 示范数据准备 | 若映射表存在则全含 |
+| 图5 | Model Training | 训练参数区：Algorithm 下拉 + epochs/lr/batch_size 输入 + Run 按钮 | 展示运行入口 | 运行前状态即可 |
+| 图6 | Model Training | 结果区：C-index/指标卡片 + 预测存活曲线图（或 KM 曲线） | 展示输出阅读 | 确保图表渲染完成 |
+| 图7 | Chat with Agent | 左侧聊天记录 + 「⚡ Quick Actions」按钮行 + 右侧「Upload CSV」卡片 | 展示聊天与快捷运行 | 数据已加载更好 |
+| 图8 | Chat with Agent | 右侧「🧪 Direct Run」表单（算法下拉、时间/事件列选择、Run now 按钮） | 展示无需 LLM 的运行通道 | 需有列名下拉 |
+| 图9 | Publications | Publications 表格（Title + Paper Link） | 说明资源入口 | 表格需完整 |
+| 图10| Contact | Contact 文本卡片（地址/电话/邮箱） | 说明联系方式 | 保留标题与 caption |
+
+## 4. 分页面图文操作指南
+### 4.1 Home
+- 你来这里做什么：查看平台简介与快速上手步骤。
+- 你需要准备什么：无数据要求；熟悉自己数据的时间列与事件列名称。
+- 操作步骤：
+  1. 展开「🚀 How to Use This System」折叠块 → 阅读 5 步闭环。
+     - 检查点：看到上传→映射→选算法→解释→指标的列表。
+  2. 如需概念复习，下滑查看「What is Survival Analysis?」与研究方向折叠块。
+     - 检查点：折叠块能展开，文字可读。
+- 输出怎么解读：无数值输出；此页只提供入口与背景。
+- 导出/复现：可截图折叠块内容作为培训材料。
+
+### 4.2 Algorithm Tutor
+- 你来这里做什么：学习生存分析概念、查看 TEXGISA 方法与算法比较、生成交互式曲线演示。
+- 你需要准备什么：无数据；只需浏览。
+- 操作步骤：
+  1. 展开「📚 Core Survival Analysis Concepts」→ 调整「Median Survival」「Hazard Ratio」滑块。
+     - 检查点：Hazard vs. Time 与 Survival vs. Time 图同步变化；播放/暂停按钮可用。
+     - 常见错误：滑块超出范围（6–60 月、0.5–2.0），UI 不响应 → 刷新页面。
+  2. 下拉「🔍 Choose an Algorithm to Explore」选择算法（CoxTime/DeepSurv/DeepHit/TEXGISA）。
+     - 检查点：出现对应说明与图表；若没有，确认已选择非 "Select Algorithm"。
+  3. 展开「🧭 Algorithm Comparison Guide」查看表格徽章说明差异。
+- 输出怎么解读：
+  - 动画：曲线/颜色含义以图例为准；无图例时只看趋势（hazard 越高，存活下降越快）。
+  - 各算法区：阅读公式/图表理解模型特点。
+- 导出/复现：按截图清单截取动画与算法说明；无需导出文件。
+
+### 4.3 Model Training（Run Models）
+- 你来这里做什么：上传数据、映射列、选择算法并训练，查看指标与曲线。
+- 你需要准备什么：
+  - CSV 文件，至少包含表头示例：`duration,event,feature1,feature2`
+  - event 允许值：0/1（若为 True/False、Yes/No，请先转换为 1/0）。
+  - duration 列需数值；非数值特征会被自动忽略或需提前编码；空值请先填补。
+- 操作步骤（以 TEXGISA 为例）：
+  1. 点击「Upload CSV」选择文件。
+     - 检查点：显示行列数、列名列表；若失败，错误提示会出现。
+     - 常见错误：编码/分隔符异常 → 确认 UTF-8、逗号分隔。
+  2. 在映射区选择 Time column = duration；Event column = event（或手动选择）。
+     - 检查点：下拉显示所选列；event 需映射为 0/1。
+     - 常见错误：事件列含非二元值 → 预处理为 0/1 再上传。
+  3. 选择 Algorithm（TEXGISA/CoxTime/DeepSurv/DeepHit），设置 Epochs、Learning rate、Batch size。
+     - 检查点：数值框接受输入；超界会被限制。
+     - 常见错误：学习率过大导致发散 → 先用 0.001–0.01。
+  4. 点击 Run；等待进度结束。
+     - 检查点：无报错，结果区出现指标与图表。
+  5. 展开 Feature Importance（若算法支持）查看 Top-k 特征方向与权重。
+- 输出怎么解读：
+  - C-index：>0.6 一般表示有区分度；接近 0.5 需检查数据或特征。
+  - 预测存活曲线：分离度大说明风险异质性明显。
+  - KM 曲线：阶梯下降；尾部长平段多为删失。
+  - Feature Importance：颜色/方向以图例为准；若无图例，仅按排序看重要度，不解读方向。
+- 导出/复现：使用结果区的下载按钮导出表格/特征重要性；记录所选时间列、事件列、算法与参数。
+
+### 4.4 Chat with Agent
+- 你来这里做什么：聊天询问操作、直接运行算法、查看结构化输出。
+- 你需要准备什么：CSV 数据；知道时间列/事件列名称。
+- 操作步骤：
+  1. 右侧「Upload CSV」上传数据。
+     - 检查点：成功提示显示文件名与行列数；列名可在 Show columns 展开。
+     - 常见错误：无法加载 → 确认 CSV 格式、字段名无空列。
+  2. 左侧「⚡ Quick Actions」若已识别列名，直接点击 Run TEXGISA / CoxTime / DeepSurv / DeepHit。
+     - 检查点：运行后聊天区出现结果摘要；若 disabled，说明未加载数据。
+  3. 右侧「🧪 Direct Run」表单：选择 Algorithm、Time column、Event column、Epochs/LR/Batch size → Run now。
+     - 检查点：运行后结果卡片出现 C-index、存活曲线、KM；无则检查列选择。
+  4. 若需自然语言指令，在底部 chat_input 输入 “run deepsurv time=duration event=event”。
+     - 检查点：Agent 回复包含运行状态或要求补充列名。
+- 输出怎么解读：同 Model Training；聊天回复会总结指标与图表位置。
+- 导出/复现：使用结果卡片的下载按钮；聊天记录可复制保存。
+
+### 4.5 Publications
+- 你来这里做什么：查看论文链接。
+- 操作步骤：无需上传；直接查看表格点击 Paper Link。
+- 输出怎么解读：Link 列显示可点击的论文链接。
+- 导出/复现：可复制链接或截图表格。
+
+### 4.6 Contact
+- 你来这里做什么：获取联系方式。
+- 操作步骤：直接查看地址、电话、邮箱。
+- 输出怎么解读：按需拨打或发送邮件。
+- 导出/复现：截图或复制联系方式。
+
+## 5. 常见问题与排错（FAQ）
+- 症状：上传后识别不到列
+  - 原因：CSV 分隔符/编码异常或表头缺失
+  - 解决步骤：确认 UTF-8、逗号分隔，首行含列名；重新上传
+- 症状：duration/event 选错
+  - 原因：时间列/事件列命名不清或混入字符
+  - 解决步骤：在映射下拉中手动选择正确列；确保事件列仅含 0/1
+- 症状：指标为空/报错
+  - 原因：数据含空值、非数值特征或训练参数非法
+  - 解决步骤：清洗缺失，确保数值列；将学习率/批量改为默认；重试
+- 症状：KM 图很奇怪（大量 censoring）
+  - 原因：事件比例过低或随访时间短
+  - 解决步骤：检查事件率；必要时延长随访或过滤异常值；关注 C-index 是否仍可用
+- 症状：Feature Importance 无颜色/方向
+  - 原因：当前运行未启用方向信息或算法不支持
+  - 解决步骤：选择 TEXGISA 并启用包含方向的解释（若有）；否则记录为 TODO
+- 症状：LLM/Agent 不可用
+  - 原因：离线或缺少 Token
+  - 解决步骤：改用右侧「🧪 Direct Run」直接训练；或在 Model Training 页面运行
+- 症状：运行很慢
+  - 原因：epochs 太大、batch_size 太小、解释计算耗时
+  - 解决步骤：先用 epochs 80–120、batch_size ≥32、关闭重度解释；确认硬件资源
+- 症状：特征方向与临床认知相反
+  - 原因：特征未标准化或数据质量问题
+  - 解决步骤：检查预处理；必要时在算法设置中提高平滑/先验权重（若支持）
+
+## 6. 术语速查（Glossary）
+- 生存时间 / Survival Time / 事件发生所用时间 / Algorithm Tutor 动画、训练列映射
+- 事件指示 / Event Indicator / 1=事件、0=删失 / 映射下拉、Direct Run 表单
+- 删失 / Censoring / 未观察到事件的样本 / KM 曲线解读、算法输入
+- 一致性指数 / C-index / 排序一致性的指标，越高越好 / 结果卡片、聊天摘要
+- Kaplan–Meier 曲线 / KM / 经验存活曲线，阶梯下降 / 结果区图表
+- 危险率 / Hazard / 瞬时风险，越高表示事件越快 / Algorithm Tutor 动画、算法说明
+- 存活概率 / Survival Probability / 1-累计风险 / Algorithm Tutor 动画、结果曲线
+- 特征重要性 / Feature Importance / 变量对风险的贡献 / TEXGISA 结果区
+- 训练轮数 / Epochs / 完整遍历训练数据的次数 / Model Training、Direct Run 表单
+- 学习率 / Learning Rate / 参数更新步长 / Model Training、Direct Run 表单


### PR DESCRIPTION
## Summary
- add top-level reading shortcuts, clearer version info, and a concise scope note for compiled UI guides
- simplify quick start to a single default path with optional chat route and provide a minimal CSV header template and data rules
- soften color/direction assertions to rely on legends and clarify platform limitations for new users

## Testing
- not run (documentation only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942c44af3f0832b9d329525cf53e5e3)