### PR TITLE
Add confirmation gate for chat model runs

### DIFF
--- a/docs/chat_confirmation_guide_zh.md
+++ b/docs/chat_confirmation_guide_zh.md
@@ -1,0 +1,22 @@
+# Chat 页面确认执行流程说明
+
+本文档用中文概述最近在“Chat with Survival Analysis Agent”页面增加的功能，以及在代码中的主要实现方式，方便后续维护和对接。
+
+## 新增功能概览
+- **显式确认再执行**：无论是快速按钮、表单提交还是聊天指令触发模型运行，都会先入队待确认动作，只有用户回复 `yes` 或 `no` 后才执行或取消。
+- **聊天上下文提示**：在向代理调用时自动注入当前数据集状态和规则，提醒代理在运行训练/预览前务必询问确认，并指明可用算法及时间/事件列要求。
+- **待确认提示与取消**：当存在挂起操作时，界面会显示警告，用户回复 `no` 会立即取消并记录到对话历史。
+- **结果持久化展示**：直接运行完成后会缓存结果与原始数据，用于下方结果区域绘制生存曲线、特征重要性和 Kaplan–Meier。
+
+## 关键实现节点
+- **上下文构建**：`_context_string()` 根据 `DataManager` 提供的摘要拼接数据是否已加载、列名列表和算法指南，作为系统提示传递给 `sa_agent`，并强制要求“执行前询问 yes/no”。【F:pages_logic/chat_with_agent.py†L16-L55】
+- **确认队列**：`_queue_confirmation()` 将待执行的函数与参数存入 `st.session_state["pending_action"]`，`_run_pending_if_confirmed()` 解析用户回复，遇到非 yes/no 会再次提示；回复 `yes` 时带 spinner 调用实际函数并保存结果，回复 `no` 则取消并写入历史。【F:pages_logic/chat_with_agent.py†L64-L105】
+- **快速操作与表单**：四个快速按钮和右侧“Direct Run”表单提交时，都用 `_queue_confirmation` 包裹实际运行函数 `_run_direct`，并在对话区追加“即将执行，请回复 yes/no”的提示，保证界面触发也遵循确认流程。【F:pages_logic/chat_with_agent.py†L334-L409】【F:pages_logic/chat_with_agent.py†L438-L472】
+- **聊天输入拦截**：在 `show()` 内处理 `st.chat_input` 时，若存在 `pending_action` 会优先调用 `_run_pending_if_confirmed`；否则根据文本匹配 preview/TEXGISA 的命令直接入队确认，其他自由文本则带上上下文调用代理。这样聊天触发的动作同样需要明确的 yes/no 才会运行。【F:pages_logic/chat_with_agent.py†L411-L456】
+- **结果渲染与状态维护**：`_run_direct` 在运行模型后把结果和数据存入 session，以供 `_render_results` 绘制指标、TEXGISA 特征重要性、生存曲线和 KM 曲线，并在聊天历史中记录“Started: xxx”提示。【F:pages_logic/chat_with_agent.py†L288-L332】【F:pages_logic/chat_with_agent.py†L203-L287】
+
+## 使用说明
+1. 上传 CSV 后，界面会显示列名与行列数，快速按钮会使用 `duration/event` 或自动推测的列名生成默认配置。
+2. 点击快速按钮或提交右侧表单后，聊天区会出现“即将执行，请回复 yes/no”的消息，用户必须回复 `yes` 才会真正运行；`no` 则取消。
+3. 在聊天框输入 `run texgisa time=duration event=event` 等指令，也会先入队待确认；非命令类问题则交给代理回答。
+4. 运行结束后，结果区域会显示关键指标、生存曲线与 KM 图等，可根据需要多次运行不同算法。

--- a/pages_logic/chat_with_agent.py
+++ b/pages_logic/chat_with_agent.py
@@ -59,6 +59,7 @@ def _context_string():
         "- If DATASET_LOADED is False, you MUST say the dataset is not loaded and ask the user to upload a CSV on the right panel.\n"
         "- Never claim to have inspected or loaded data unless DATASET_LOADED is True.\n"
         "- When the user requests an algorithm, select from TEXGISA, CoxTime, DeepSurv, or DeepHit and confirm the time/event columns.\n"
+        "- Before executing training or preview runs, explicitly ask the user to reply 'yes' or 'no'. Only proceed after they answer.\n"
         "- Prefer the preview/train/run shortcuts when the user wants quick execution; otherwise ask for the time/event columns explicitly.\n"
         "ALGORITHMS:\n"
         + "\n".join(algo_lines)
@@ -71,6 +72,53 @@ def _ensure_data_manager():
     if "data_manager" not in st.session_state:
         from sa_data_manager import DataManager
         st.session_state.data_manager = DataManager()
+
+
+def _queue_confirmation(label: str, fn, kwargs: dict):
+    """Store a pending action that requires an explicit yes/no before execution."""
+    st.session_state["pending_action"] = {
+        "label": label,
+        "fn": fn,
+        "kwargs": kwargs,
+    }
+
+
+def _run_pending_if_confirmed(response_text: str) -> bool:
+    """Handle a yes/no response for the queued action.
+
+    Returns True if the response was a valid confirmation (yes or no), False otherwise.
+    """
+    pending = st.session_state.get("pending_action")
+    if not pending:
+        return False
+
+    answer = response_text.strip().lower()
+    if answer not in {"yes", "y", "no", "n"}:
+        # Ask the user to answer explicitly.
+        with st.chat_message("assistant"):
+            st.markdown("Please reply with **yes** or **no** to continue the pending action.")
+        st.session_state.chat_messages.append(AIMessage(content="Please reply yes or no to continue."))
+        return True
+
+    if answer in {"no", "n"}:
+        msg = f"Canceled: {pending['label']}"
+        with st.chat_message("assistant"):
+            st.markdown(msg)
+        st.session_state.chat_messages.append(AIMessage(content=msg))
+        st.session_state.pop("pending_action", None)
+        return True
+
+    # User confirmed
+    with st.chat_message("assistant"):
+        st.markdown(f"Running: {pending['label']}")
+        with st.spinner("Executing requested analysis..."):
+            res = pending["fn"](**pending["kwargs"])
+    st.session_state.chat_messages.append(AIMessage(content=f"Started: {pending['label']}"))
+    st.session_state.pop("pending_action", None)
+    # Preserve last results for the result panel when _run_direct returns a dict
+    if isinstance(res, dict):
+        st.session_state["last_results"] = res
+    return True
 
 
 def _style():
@@ -430,6 +478,8 @@ def show():
         st.session_state.chat_messages = []
     if "chat_greeted" not in st.session_state:
         st.session_state.chat_greeted = False
+    if "pending_action" not in st.session_state:
+        st.session_state.pending_action = None
 
     # ---- data uploader (RIGHT column) ----
     left, right = st.columns([0.68, 0.32], gap="large")
@@ -481,6 +531,10 @@ def show():
     with left:
         _render_history(st.session_state.chat_messages)
 
+        pending = st.session_state.get("pending_action")
+        if pending:
+            st.warning(f"Pending confirmation: {pending['label']}. Reply 'yes' or 'no' to proceed.")
+
         # Quick chips (only meaningful after data is present)
         st.markdown("### ⚡ Quick Actions")
         with st.container():
@@ -494,19 +548,28 @@ def show():
             with cols_qa[0]:
                 if st.button("Run TEXGISA (no expert)", use_container_width=True, disabled=not has_data):
                     t = tcol or "duration"; e = ecol or "event"
-                    _run_direct("TEXGISA", t, e, epochs=120, include_importance=False)
+                    label = f"Run TEXGISA (time={t}, event={e}, epochs=120)"
+                    _queue_confirmation(label, _run_direct, {"algorithm_name": "TEXGISA", "time_col": t, "event_col": e, "epochs": 120, "include_importance": False})
+                    prompt = f"About to {label}. Reply **yes** to proceed or **no** to cancel."
+                    st.session_state.chat_messages.append(AIMessage(content=prompt))
             with cols_qa[1]:
                 if st.button("Run CoxTime", use_container_width=True, disabled=not has_data):
                     t = tcol or "duration"; e = ecol or "event"
-                    _run_direct("CoxTime", t, e, epochs=120)
+                    label = f"Run CoxTime (time={t}, event={e}, epochs=120)"
+                    _queue_confirmation(label, _run_direct, {"algorithm_name": "CoxTime", "time_col": t, "event_col": e, "epochs": 120})
+                    st.session_state.chat_messages.append(AIMessage(content=f"About to {label}. Reply yes or no."))
             with cols_qa[2]:
                 if st.button("Run DeepSurv", use_container_width=True, disabled=not has_data):
                     t = tcol or "duration"; e = ecol or "event"
-                    _run_direct("DeepSurv", t, e, epochs=120)
+                    label = f"Run DeepSurv (time={t}, event={e}, epochs=120)"
+                    _queue_confirmation(label, _run_direct, {"algorithm_name": "DeepSurv", "time_col": t, "event_col": e, "epochs": 120})
+                    st.session_state.chat_messages.append(AIMessage(content=f"About to {label}. Reply yes or no."))
             with cols_qa[3]:
                 if st.button("Run DeepHit", use_container_width=True, disabled=not has_data):
                     t = tcol or "duration"; e = ecol or "event"
-                    _run_direct("DeepHit", t, e, epochs=120)
+                    label = f"Run DeepHit (time={t}, event={e}, epochs=120)"
+                    _queue_confirmation(label, _run_direct, {"algorithm_name": "DeepHit", "time_col": t, "event_col": e, "epochs": 120})
+                    st.session_state.chat_messages.append(AIMessage(content=f"About to {label}. Reply yes or no."))
             st.markdown('</div>', unsafe_allow_html=True)
 
         # handle injected quick action
@@ -520,6 +583,11 @@ def show():
         if user_text:
             text = user_text.strip()
             low = text.lower()
+
+            # Handle yes/no for any pending action first
+            if st.session_state.get("pending_action"):
+                if _run_pending_if_confirmed(text):
+                    st.stop()
 
             # 取列名猜测
             stt = _dataset_state()
@@ -550,7 +618,9 @@ def show():
                 t = _get_arg(r"time(?:_col)?\s*=\s*([\w\.\-]+)", t_guess)
                 e = _get_arg(r"event(?:_col)?\s*=\s*([\w\.\-]+)", e_guess)
                 ep = _get_arg(r"epochs\s*=\s*(\d+)", 80, int)
-                _run_direct("TEXGISA", t, e, epochs=ep, preview=True, include_importance=False)
+                label = f"Preview TEXGISA feature importance (time={t}, event={e}, epochs={ep})"
+                _queue_confirmation(label, _run_direct, {"algorithm_name": "TEXGISA", "time_col": t, "event_col": e, "epochs": ep, "preview": True, "include_importance": False})
+                st.session_state.chat_messages.append(AIMessage(content=f"Queued: {label}. Reply yes or no to execute."))
                 st.stop()
 
             if (
@@ -565,7 +635,9 @@ def show():
                 t = _get_arg(r"time(?:_col)?\s*=\s*([\w\.\-]+)", t_guess)
                 e = _get_arg(r"event(?:_col)?\s*=\s*([\w\.\-]+)", e_guess)
                 ep = _get_arg(r"epochs\s*=\s*(\d+)", 150, int)
-                _run_direct("TEXGISA", t, e, epochs=ep, preview=False, include_importance=False)
+                label = f"Run TEXGISA (time={t}, event={e}, epochs={ep})"
+                _queue_confirmation(label, _run_direct, {"algorithm_name": "TEXGISA", "time_col": t, "event_col": e, "epochs": ep, "preview": False, "include_importance": False})
+                st.session_state.chat_messages.append(AIMessage(content=f"Queued: {label}. Reply yes to start or no to cancel."))
                 st.stop()
 
             # 其他自由文本 -> 走 LLM（但会被 B 步的上下文“约束”）
@@ -604,16 +676,23 @@ def show():
 
                 submitted = st.form_submit_button("Run now")
                 if submitted:
-                    _run_direct(
-                        "TEXGISA" if algo.startswith("TEXGISA") else algo,
-                        time_col,
-                        event_col,
-                        epochs=epochs,
-                        lr=lr,
-                        batch_size=batch_size,
-                        preview=False,
-                        include_importance=False,
+                    algo_name = "TEXGISA" if algo.startswith("TEXGISA") else algo
+                    label = f"Run {algo_name} (time={time_col}, event={event_col}, epochs={epochs}, lr={lr}, batch={batch_size})"
+                    _queue_confirmation(
+                        label,
+                        _run_direct,
+                        {
+                            "algorithm_name": algo_name,
+                            "time_col": time_col,
+                            "event_col": event_col,
+                            "epochs": epochs,
+                            "lr": lr,
+                            "batch_size": batch_size,
+                            "preview": False,
+                            "include_importance": False,
+                        },
                     )
+                    st.session_state.chat_messages.append(AIMessage(content=f"About to {label}. Reply yes or no to continue."))
         else:
             st.info("Upload a CSV to enable direct runs.")
         st.markdown("</div>", unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- add explicit yes/no confirmation queue for chat quick actions, form submissions, and typed commands before running survival models
- surface pending confirmations in chat history and warn users while awaiting responses
- extend agent context to remind it to request confirmation before executing analyses
- document the confirmation workflow for the chat page in `docs/chat_confirmation_guide_zh.md`

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69432730dc08832b85b1e8c2d715e619)