### PR TITLE
Add quick-action column selectors

### DIFF
--- a/pages_logic/chat_with_agent.py
+++ b/pages_logic/chat_with_agent.py
@@ -85,6 +85,18 @@ def _queue_confirmation(label: str, fn, kwargs: dict):
     }
 
 
+def _queue_and_prompt(label: str, fn, kwargs: dict, prompt: str, *, rerun: bool = False):
+    """Queue a confirmation request and immediately surface the prompt.
+
+    When rerun=True, the page reruns right away so the new assistant message and
+    pending warning are visible without needing additional user input.
+    """
+    _queue_confirmation(label, fn, kwargs)
+    st.session_state.chat_messages.append(AIMessage(content=prompt))
+    if rerun:
+        st.rerun()
+
+
 def _run_pending_if_confirmed(response_text: str) -> bool:
     """Handle a yes/no response for the queued action.
 
@@ -543,35 +555,87 @@ def show():
             st.markdown('<div class="chip-row">', unsafe_allow_html=True)
             summary = st.session_state.data_manager.get_data_summary()
             tcol, ecol = (None, None)
+            cols = []
             if "error" not in summary:
                 tcol, ecol = _guess_cols_from_summary(summary)
+                cols = summary.get("column_names", []) or []
+
+            # Allow the user to pick the time/event columns used by the quick buttons.
+            st.caption("Select time/event columns for quick runs and confirmations.")
+            qc1, qc2 = st.columns(2)
+            default_time = tcol or ("duration" if "duration" in cols else (cols[0] if cols else "duration"))
+            default_event = ecol or ("event" if "event" in cols else (cols[1] if len(cols) > 1 else default_time))
+
+            if "qa_time_col" not in st.session_state:
+                st.session_state.qa_time_col = default_time
+            if "qa_event_col" not in st.session_state:
+                st.session_state.qa_event_col = default_event
+
+            with qc1:
+                st.session_state.qa_time_col = st.selectbox(
+                    "Time column",
+                    options=cols or [default_time],
+                    index=(cols.index(st.session_state.qa_time_col)
+                           if cols and st.session_state.qa_time_col in cols else 0),
+                    key="qa_time_select",
+                )
+            with qc2:
+                st.session_state.qa_event_col = st.selectbox(
+                    "Event column",
+                    options=cols or [default_event],
+                    index=(cols.index(st.session_state.qa_event_col)
+                           if cols and st.session_state.qa_event_col in cols else 0),
+                    key="qa_event_select",
+                )
+
+            btn_disabled = not has_data or not st.session_state.qa_time_col or not st.session_state.qa_event_col
 
             cols_qa = st.columns(4)
             with cols_qa[0]:
-                if st.button("Run TEXGISA (no expert)", use_container_width=True, disabled=not has_data):
-                    t = tcol or "duration"; e = ecol or "event"
+                if st.button("Run TEXGISA (no expert)", use_container_width=True, disabled=btn_disabled):
+                    t = st.session_state.qa_time_col; e = st.session_state.qa_event_col
                     label = f"Run TEXGISA (time={t}, event={e}, epochs=120)"
-                    _queue_confirmation(label, _run_direct, {"algorithm_name": "TEXGISA", "time_col": t, "event_col": e, "epochs": 120, "include_importance": False})
                     prompt = f"About to {label}. Reply **yes** to proceed or **no** to cancel."
-                    st.session_state.chat_messages.append(AIMessage(content=prompt))
+                    _queue_and_prompt(
+                        label,
+                        _run_direct,
+                        {"algorithm_name": "TEXGISA", "time_col": t, "event_col": e, "epochs": 120, "include_importance": False},
+                        prompt,
+                        rerun=True,
+                    )
             with cols_qa[1]:
-                if st.button("Run CoxTime", use_container_width=True, disabled=not has_data):
-                    t = tcol or "duration"; e = ecol or "event"
+                if st.button("Run CoxTime", use_container_width=True, disabled=btn_disabled):
+                    t = st.session_state.qa_time_col; e = st.session_state.qa_event_col
                     label = f"Run CoxTime (time={t}, event={e}, epochs=120)"
-                    _queue_confirmation(label, _run_direct, {"algorithm_name": "CoxTime", "time_col": t, "event_col": e, "epochs": 120})
-                    st.session_state.chat_messages.append(AIMessage(content=f"About to {label}. Reply yes or no."))
+                    _queue_and_prompt(
+                        label,
+                        _run_direct,
+                        {"algorithm_name": "CoxTime", "time_col": t, "event_col": e, "epochs": 120},
+                        f"About to {label}. Reply yes or no.",
+                        rerun=True,
+                    )
             with cols_qa[2]:
-                if st.button("Run DeepSurv", use_container_width=True, disabled=not has_data):
-                    t = tcol or "duration"; e = ecol or "event"
+                if st.button("Run DeepSurv", use_container_width=True, disabled=btn_disabled):
+                    t = st.session_state.qa_time_col; e = st.session_state.qa_event_col
                     label = f"Run DeepSurv (time={t}, event={e}, epochs=120)"
-                    _queue_confirmation(label, _run_direct, {"algorithm_name": "DeepSurv", "time_col": t, "event_col": e, "epochs": 120})
-                    st.session_state.chat_messages.append(AIMessage(content=f"About to {label}. Reply yes or no."))
+                    _queue_and_prompt(
+                        label,
+                        _run_direct,
+                        {"algorithm_name": "DeepSurv", "time_col": t, "event_col": e, "epochs": 120},
+                        f"About to {label}. Reply yes or no.",
+                        rerun=True,
+                    )
             with cols_qa[3]:
-                if st.button("Run DeepHit", use_container_width=True, disabled=not has_data):
-                    t = tcol or "duration"; e = ecol or "event"
+                if st.button("Run DeepHit", use_container_width=True, disabled=btn_disabled):
+                    t = st.session_state.qa_time_col; e = st.session_state.qa_event_col
                     label = f"Run DeepHit (time={t}, event={e}, epochs=120)"
-                    _queue_confirmation(label, _run_direct, {"algorithm_name": "DeepHit", "time_col": t, "event_col": e, "epochs": 120})
-                    st.session_state.chat_messages.append(AIMessage(content=f"About to {label}. Reply yes or no."))
+                    _queue_and_prompt(
+                        label,
+                        _run_direct,
+                        {"algorithm_name": "DeepHit", "time_col": t, "event_col": e, "epochs": 120},
+                        f"About to {label}. Reply yes or no.",
+                        rerun=True,
+                    )
             st.markdown('</div>', unsafe_allow_html=True)
 
         # handle injected quick action

--- a/sa_tools.py
+++ b/sa_tools.py
@@ -4,6 +4,10 @@ import json
 from typing import Any, Dict
 
 import streamlit as st
+try:  # pragma: no cover - optional when Streamlit isn't running
+    from streamlit.runtime.scriptrunner import get_script_run_ctx
+except Exception:  # pragma: no cover
+    get_script_run_ctx = None  # type: ignore
 import pandas as pd
 from models import coxtime, deepsurv, deephit
 
@@ -123,10 +127,19 @@ def run_survival_analysis(
     # Ensure the shared DataManager exists in the current session; fall back to the
     # most recently used manager when tools run in a background thread without a
     # ScriptRunContext.
+    ctx_available = False
     try:
-        dm = st.session_state.get("data_manager")
+        if get_script_run_ctx is not None and get_script_run_ctx() is not None:
+            ctx_available = True
     except Exception:
-        dm = None
+        ctx_available = False
+
+    dm = None
+    if ctx_available:
+        try:
+            dm = st.session_state.get("data_manager")
+        except Exception:
+            dm = None
 
     if dm is None:
         from sa_data_manager import get_shared_manager
@@ -318,10 +331,19 @@ def explain_hyperparameter(param_name: str) -> dict:
 
 def get_data_summary() -> dict:
     """Retrieves a summary of the currently loaded dataset."""
+    ctx_available = False
     try:
-        dm = st.session_state.get("data_manager")
+        if get_script_run_ctx is not None and get_script_run_ctx() is not None:
+            ctx_available = True
     except Exception:
-        dm = None
+        ctx_available = False
+
+    dm = None
+    if ctx_available:
+        try:
+            dm = st.session_state.get("data_manager")
+        except Exception:
+            dm = None
 
     if dm is None:
         from sa_data_manager import get_shared_manager


### PR DESCRIPTION
## Summary
- add time/event column selectors above the quick-action buttons so users choose which fields to run with
- persist the selected columns in session state and disable quick actions when selections are missing to avoid unintended runs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943917b9088832bbd86c4acbd5410fd)