### PR TITLE
Remove unavailable texgisa-survival PyPI dependency from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,5 @@ requests==2.32.2
 pytest==8.2.2
 
 # Optional TEXGISA package backend (dual-path integration)
-texgisa-survival>=0.1.0
+# NOTE: not published on PyPI; install separately from GitHub when needed.
+# pip install "git+https://github.com/Kunjoe7/texgisa-survival.git@main"


### PR DESCRIPTION
### Motivation
- The optional package `texgisa-survival>=0.1.0` is not published on PyPI and causes `pip install -r requirements.txt` to fail during Streamlit deployments.

### Description
- Removed the `texgisa-survival>=0.1.0` entry from `requirements.txt` and replaced it with a commented note pointing to the GitHub install command for optional manual installation.

### Testing
- Ran `python -m pip install --dry-run -r requirements.txt` which completed successfully and no longer reports the `No matching distribution found for texgisa-survival` error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0d6eaa8d0832bbc2d7d303be72847)